### PR TITLE
(maint) Fix incorrectly named method

### DIFF
--- a/server/lib/puppet-languageserver/simple_tcp_server.rb
+++ b/server/lib/puppet-languageserver/simple_tcp_server.rb
@@ -35,7 +35,7 @@ module PuppetLanguageServer
     end
 
     # @api public
-    def close_connection?
+    def close_connection
       socket.close
     end
   end


### PR DESCRIPTION
The `close_connection` method closes the connection it does not return a boolean
as indicated by the question mark at the end.  This commit removes the errant
character.