### PR TITLE
(maint) Fix block commenting

### DIFF
--- a/client/languages/puppet.configuration.json
+++ b/client/languages/puppet.configuration.json
@@ -1,9 +1,9 @@
 {
   "comments": {
     // symbol used for single line comment. Remove this entry if your language does not support line comments
-    "lineComment": ["#","//"],
+    "lineComment": "#",
     // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-    "blockComment": [ "/*", "*/" ]
+    "blockComment": "#"
   },
   // symbols used as brackets
   "brackets": [

--- a/client/package.json
+++ b/client/package.json
@@ -34,7 +34,7 @@
       "id": "puppet",
       "aliases": ["Puppet", "puppet"],
       "extensions": [".pp", ".epp"],
-      "configuration": "./puppet.configuration.json"
+      "configuration": "./languages/puppet.configuration.json"
     }],
     "grammars": [{
       "language": "puppet",


### PR DESCRIPTION
Previously the block commenting was configured but was not be applied.  This
commit changes the configuration to use the correct location of configuration
file.

This commit also changes the comment style to always the hash character '#' as
per the puppet language documentation.