### PR TITLE
Add Packaging task to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-out
-node_modules

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,6 @@
+out/
+node_modules/
+vendor/
+
+// Ignore generated module output
+*.vsix

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -1,0 +1,35 @@
+// Include gulp
+var gulp = require('gulp');
+var del = require('del');
+var runSequence = require('run-sequence');
+var exec = require('child_process').exec;
+
+// The default task (called when you run `gulp` from cli) 
+gulp.task('default', ['build']);
+
+gulp.task('clean', function () {
+  return del(['vendor'])
+})
+
+gulp.task('copy_language_server', function () {
+  return gulp.src(['../server/lib/**/*',
+                   '../server/vendor/**/*',
+                   '../server/puppet-languageserver'
+                  ], { base: '../server'})
+             .pipe(gulp.dest('./vendor/languageserver'));
+})
+
+gulp.task('build_extension', function (callback) {
+  exec('node ./node_modules/vsce/out/vsce package',
+    function (err, stdout, stderr) {
+      console.log(stdout);
+      console.log(stderr);
+      callback;
+    });
+})
+
+
+gulp.task('build', function (callback) {
+  runSequence('clean','copy_language_server','build_extension',callback);
+})
+

--- a/client/package.json
+++ b/client/package.json
@@ -78,7 +78,11 @@
   "devDependencies": {
     "typescript": "^2.0.3",
     "vscode": "^1.0.0",
+    "vsce": "^1.18.0",
     "mocha": "^2.3.3",
+    "gulp": "^3.9.1",
+    "del": "^2.2.2",
+    "run-sequence":"^1.2.2",
     "@types/node": "^6.0.40",
     "@types/mocha": "^2.2.32"
   },


### PR DESCRIPTION
Previously the language server source files were not transferred to the client
directory so they could be consumed by the client.  This commit
- Adds four gulp tasks; build, clean, copy_language_server and  build_extension
- Moves the .gitignore from the root into the client.  The ignore file is not
  needed in the root
- Gitignore in `client/` adds the vendor folder (which is where the language
  server code ends up) and any generated artifacts (*.vsix) to the ignore list.
  Note that the vsix filter only applies to files within the client folder, not
  in the root directory.