### PR TITLE
Add more Puppet preloading to language server

### DIFF
--- a/server/lib/puppet-languageserver.rb
+++ b/server/lib/puppet-languageserver.rb
@@ -76,6 +76,12 @@ module PuppetLanguageServer
     if options[:preload_puppet]
       LogMessage('information', "Preloading Facter (Async)...")
       PuppetLanguageServer::FacterHelper.load_facts_async
+
+      LogMessage('information', "Preloading Puppet Types (Async)...")
+      PuppetLanguageServer::PuppetHelper.load_types_async
+
+      LogMessage('information', "Preloading Functions (Async)...")
+      PuppetLanguageServer::PuppetHelper.load_functions_async
     else
       LogMessage('information', "Skipping preloading Puppet")
     end

--- a/server/lib/puppet-languageserver/puppet_helper.rb
+++ b/server/lib/puppet-languageserver/puppet_helper.rb
@@ -51,6 +51,12 @@ module PuppetLanguageServer
       end
     end
 
+    def self.load_functions_async
+      Thread.new do
+        load_functions
+      end
+    end
+
     def self.functions
       result = []
       @ops_lock_funcs.synchronize do


### PR DESCRIPTION
Previously on the Facter facts were preloaded.  This commit changes the
behaviour to preload Pupept Types and Functions asynchronously as well.