### PR TITLE
add a vscode task to run gulp

### DIFF
--- a/client/.vscode/tasks.json
+++ b/client/.vscode/tasks.json
@@ -7,24 +7,37 @@
 // ${cwd}: the current working directory of the spawned process
 
 // A task runner that calls a custom npm script that compiles the extension.
+// {
+//     "version": "0.1.0",
+
+//     // we want to run npm
+//     "command": "npm",
+
+//     // the command is a shell script
+//     "isShellCommand": true,
+
+//     // show the output window only if unrecognized errors occur.
+//     "showOutput": "silent",
+
+//     // we run the custom script "compile" as defined in package.json
+//     "args": ["run", "compile", "--loglevel", "silent"],
+
+//     // The tsc compiler is started in watching mode
+//     "isWatching": true,
+
+//     // use the standard tsc in watch mode problem matcher to find compile problems in the output.
+//     "problemMatcher": "$tsc-watch"
+// }
+
 {
-    "version": "0.1.0",
-
-    // we want to run npm
-    "command": "npm",
-
-    // the command is a shell script
-    "isShellCommand": true,
-
-    // show the output window only if unrecognized errors occur.
-    "showOutput": "silent",
-
-    // we run the custom script "compile" as defined in package.json
-    "args": ["run", "compile", "--loglevel", "silent"],
-
-    // The tsc compiler is started in watching mode
-    "isWatching": true,
-
-    // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-    "problemMatcher": "$tsc-watch"
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "taskName": "gulp",
+            "command": "gulp",
+            "isBuildCommand": true,
+            "showOutput": "always",
+            "isBackground": true
+        }
+    ]
 }


### PR DESCRIPTION
This adds a background task to run gulp, which builds the ruby language server, vendors it so the client can access it, and then packages the vscode extension