### PR TITLE
fix npm task in tasks.json

### DIFF
--- a/client/.vscode/tasks.json
+++ b/client/.vscode/tasks.json
@@ -6,38 +6,25 @@
 // ${fileExtname}: the current opened file's extension
 // ${cwd}: the current working directory of the spawned process
 
-// A task runner that calls a custom npm script that compiles the extension.
-// {
-//     "version": "0.1.0",
-
-//     // we want to run npm
-//     "command": "npm",
-
-//     // the command is a shell script
-//     "isShellCommand": true,
-
-//     // show the output window only if unrecognized errors occur.
-//     "showOutput": "silent",
-
-//     // we run the custom script "compile" as defined in package.json
-//     "args": ["run", "compile", "--loglevel", "silent"],
-
-//     // The tsc compiler is started in watching mode
-//     "isWatching": true,
-
-//     // use the standard tsc in watch mode problem matcher to find compile problems in the output.
-//     "problemMatcher": "$tsc-watch"
-// }
-
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "taskName": "gulp",
-            "command": "gulp",
-            "isBuildCommand": true,
-            "showOutput": "always",
-            "isBackground": true
-        }
-    ]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "taskName": "npm",
+      "command": "npm",
+      "isShellCommand":true,
+      "showOutput": "silent",
+      "args": ["run", "compile", "--loglevel", "silent"],
+      "isBackground": true,
+      "problemMatcher": "$tsc-watch"
+    },
+    {
+      "taskName": "gulp",
+      "command": "gulp",
+      "isBuildCommand": true,
+      "showOutput": "always",
+      "isBackground": true,
+      "suppressTaskName": true
+    }
+  ]
 }


### PR DESCRIPTION
The npm task was commented out to create the gulp task. This is needed by vscode proper, so lets put it back