### PR TITLE
Fix task runner for v2.0.0 API

### DIFF
--- a/client/.vscode/tasks.json
+++ b/client/.vscode/tasks.json
@@ -14,7 +14,7 @@
       "command": "npm",
       "isShellCommand":true,
       "showOutput": "silent",
-      "args": ["run", "compile", "--loglevel", "silent"],
+      "args": ["run", "compile"],
       "isBackground": true,
       "problemMatcher": "$tsc-watch"
     },


### PR DESCRIPTION
Previously on Windows, VSCode would not finishing compiling the client and
would never start up the extension debugging session.  This commit removes the
redudant log squashing command, which was causing VSCode to never see the
output from the compiler to say TSC had finished.