### PR TITLE
Fix resource completion typo

### DIFF
--- a/server/lib/puppet-languageserver/completion_provider.rb
+++ b/server/lib/puppet-languageserver/completion_provider.rb
@@ -197,7 +197,7 @@ module PuppetLanguageServer
           item_type = Puppet::Type.type(data['name'])
           # TODO: More things?
           completion_item['documentation'] = item_type.doc unless item_type.doc.nil?
-          completion_item['insertText'] = "#{data['name']} { '${1:title}':\n\tensure => '${2:present}'\n},"
+          completion_item['insertText'] = "#{data['name']} { '${1:title}':\n\tensure => '${2:present}'\n}"
           completion_item['insertTextFormat'] = LanguageServer::INSERTTEXTFORMAT_SNIPPET
         when 'resource_parameter'
           item_type = Puppet::Type.type(data['resource_type'])

--- a/server/lib/puppet-languageserver/puppet_parser_helper.rb
+++ b/server/lib/puppet-languageserver/puppet_parser_helper.rb
@@ -1,26 +1,23 @@
 module PuppetLanguageServer
   module PuppetParserHelper
 
-    def self.remove_char_at(content, line_num, char_num)
-      # TODO: Do we care about CRLF vs LF - I don't think so.
-      line_offset = 0
-      (1..line_num).each { |_x| line_offset = content.index("\n",line_offset + 1) unless line_offset.nil? }
+    def self.remove_char_at(content, line_offsets, line_num, char_num)
+      line_offset = line_offsets[line_num]
       raise if line_offset.nil?
 
       # Remove the offending character
-      new_content = content.slice(0,line_offset + char_num) + content.slice(line_offset + char_num + 1, content.length - 1)
+      new_content = content.slice(0,line_offset + char_num - 1) + content.slice(line_offset + char_num, content.length - 1)
 
       new_content
     end
 
-    def self.insert_text_at(content, line_num, char_num, text)
+    def self.insert_text_at(content, line_offsets, line_num, char_num, text)
       # Insert text after where the cursor is
       # This helps due to syntax errors like `$facts[]` or `ensure =>`
-      line_offset = 0
-      (1..line_num).each { |_x| line_offset = content.index("\n",line_offset + 1) unless line_offset.nil? }
+      line_offset = line_offsets[line_num]
       raise if line_offset.nil?
       # Insert the text
-      new_content = content.slice(0,line_offset + char_num + 1) + text + content.slice(line_offset + char_num + 1, content.length - 1)
+      new_content = content.slice(0,line_offset + char_num) + text + content.slice(line_offset + char_num, content.length - 1)
 
       new_content
     end
@@ -28,7 +25,7 @@ module PuppetLanguageServer
     def self.line_offsets(content)
       # Calculate all of the offsets of \n in the file
       line_offsets = [0]
-      line_offset = 0
+      line_offset = -1
       begin
         line_offset = content.index("\n",line_offset + 1)
         line_offsets << line_offset + 1 unless line_offset.nil?
@@ -63,22 +60,21 @@ module PuppetLanguageServer
           when :noop
             new_content = content
           when :remove_char
-            new_content = remove_char_at(content, line_num, char_num)
+            new_content = remove_char_at(content, line_offsets, line_num, char_num)
             move_offset = -1
           when :try_quotes
             # Perhaps try inserting double quotes.  Useful in empty arrays or during variable assignment
             # Grab the line up to the cursor character + 1
             line = get_line_at(content, line_offsets, line_num).slice!(0,char_num + 1)
-            if line.strip.end_with?('=') ||
-               line.end_with?('[]')
-              new_content = insert_text_at(content, line_num, char_num, "''")
+            if line.strip.end_with?('=') || line.end_with?('[]')
+              new_content = insert_text_at(content, line_offsets, line_num, char_num, "''")
             end
           when :try_quotes_and_comma
             # Perhaps try inserting double quotes with a comma.  Useful resource properties and parameter assignments
             # Grab the line up to the cursor character + 1
             line = get_line_at(content, line_offsets, line_num).slice!(0,char_num + 1)
             if line.strip.end_with?('=>')
-              new_content = insert_text_at(content, line_num, char_num, "'',")
+              new_content = insert_text_at(content, line_offsets, line_num, char_num, "'',")
             end
           else
             raise("Unknown parsing method #{method}")

--- a/server/spec/integration/puppet-languageserver/completion_provider_spec.rb
+++ b/server/spec/integration/puppet-languageserver/completion_provider_spec.rb
@@ -90,41 +90,63 @@ EOT
       end
     end
 
+    context '$facts variable' do
+      describe "With newlines at the beginning of the document and inside the brackets of $facts" do
+        let(:content) { <<-EOT
 
-    describe "When inside the brackets of $facts" do
-      let(:content) { <<-EOT
+# Newlines are need above to test if parsing is ok.
 $test1 = $::operatingsystem
 $test2 = $operatingsystem
 $test3 = $facts[]
 EOT
-      }
-      let(:line_num) { 2 }
-      let(:char_num) { 16 }
+        }
+        let(:line_num) { 4 }
+        let(:char_num) { 16 }
 
-      it 'should return a list of facts' do
-        result = subject.complete(content, line_num, char_num)
+        it 'should return a list of facts' do
+          result = subject.complete(content, line_num, char_num)
 
-        result['items'].each do |item|
-          expect(item).to be_completion_item_with_type('variable_expr_fact')
+          result['items'].each do |item|
+            expect(item).to be_completion_item_with_type('variable_expr_fact')
+          end
         end
       end
-    end
 
-    describe "When inside the start brackets of $facts" do
-      let(:content) { <<-EOT
+      describe "When inside the brackets of $facts" do
+        let(:content) { <<-EOT
+$test1 = $::operatingsystem
+$test2 = $operatingsystem
+$test3 = $facts[]
+EOT
+        }
+        let(:line_num) { 2 }
+        let(:char_num) { 16 }
+
+        it 'should return a list of facts' do
+          result = subject.complete(content, line_num, char_num)
+
+          result['items'].each do |item|
+            expect(item).to be_completion_item_with_type('variable_expr_fact')
+          end
+        end
+      end
+
+      describe "When inside the start brackets of $facts" do
+        let(:content) { <<-EOT
 $test1 = $::operatingsystem
 $test2 = $operatingsystem
 $test3 = $facts[
 EOT
-      }
-      let(:line_num) { 2 }
-      let(:char_num) { 16 }
+        }
+        let(:line_num) { 2 }
+        let(:char_num) { 16 }
 
-      it 'should return a list of facts' do
-        result = subject.complete(content, line_num, char_num)
+        it 'should return a list of facts' do
+          result = subject.complete(content, line_num, char_num)
 
-        result['items'].each do |item|
-          expect(item).to be_completion_item_with_type('variable_expr_fact')
+          result['items'].each do |item|
+            expect(item).to be_completion_item_with_type('variable_expr_fact')
+          end
         end
       end
     end


### PR DESCRIPTION
The resource completion had a trailing comma which generated invalid puppet
code.  This commit removes the errant comma.