### PR TITLE
Fix Language Server not stopping when client disconnects

### DIFF
--- a/server/lib/puppet-languageserver/json_rpc_handler.rb
+++ b/server/lib/puppet-languageserver/json_rpc_handler.rb
@@ -55,7 +55,7 @@ module PuppetLanguageServer
     end
 
     def unbind
-      PuppetLanguageServer::LogMessage('information','Client has disconnected to the language server')
+      PuppetLanguageServer::LogMessage('information','Client has disconnected from the language server')
     end
 
     def extract_headers(raw_header)

--- a/server/lib/puppet-languageserver/message_router.rb
+++ b/server/lib/puppet-languageserver/message_router.rb
@@ -126,7 +126,7 @@ module PuppetLanguageServer
           PuppetLanguageServer::LogMessage('information','Client has received initialization')
 
         when 'exit'
-          PuppetLanguageServer::LogMessage('information','Received exit notification.  Shutting down.')
+          PuppetLanguageServer::LogMessage('information','Received exit notification.  Closing connection to client...')
           close_connection
 
         when 'textDocument/didOpen'


### PR DESCRIPTION
Previously when the client sent an `exit` message, the language server would
attempt to close the underlying connection however it would hang, and at worst
cause high CPU usage.  This commit
- Uses the callback architecture inside the TCP Server to close connection
  instead of trying to close the TCP Socket within the same execution context.
  This stops the possibility of a race condition which can cause unexpected
  blocks
- Add a missing method `close_connection_after_writing` on the base connection
  class
- Add more logging on TCP startup to describe whether the server will close
  after the client disconnects