### PR TITLE
Speedup server startup

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -76,6 +76,7 @@ Usage: puppet-languageserver.rb [options]
     -t, --timeout=TIMEOUT            Stop the language server if a client does not connection within TIMEOUT seconds.  A value of zero will not timeout.  Default is 10 seconds
     -d, --no-preload                 Do not preload Puppet information when the language server starts.  Default is to preload
         --debug=DEBUG                Output debug information.  Either specify a filename or 'STDOUT'.  Default is no debug output
+    -s, --slow-start                 Delay starting the TCP Server until Puppet initialisation has completed.  Default is to start fast
     -h, --help                       Prints this help
 ```
 


### PR DESCRIPTION
NOTE - This builds on https://github.com/jpogran/puppet-vscode/pull/26

Previously the TCP Server would only start after parts of Puppet were
initialised.  This commit changes the startup behaviour so that the TCP Server
is running as soon as the Puppet Version can be determined, and further
initialisation is handed to a different thread.  A new command line option of
--start-slow is added, mainly for testing, to slow down the startup if required.

This will help when the server is started by the VSCode client directly so that
the TCP socket is available as soon as possible.