### PR TITLE
(GH-46) Autoload modules, not just core types

### DIFF
--- a/server/lib/puppet-languageserver/puppet_helper.rb
+++ b/server/lib/puppet-languageserver/puppet_helper.rb
@@ -119,11 +119,15 @@ module PuppetLanguageServer
 
     def self._load_types
       @types_hash = {}
-      Puppet::Type.loadall
+      # This is an expensive call
+      # From https://github.com/puppetlabs/puppet/blob/ebd96213cab43bb2a8071b7ac0206c3ed0be8e58/lib/puppet/metatype/manager.rb#L182-L189
+      typeloader = Puppet::Util::Autoload.new(self, "puppet/type")
+      typeloader.loadall
 
       Puppet::Type.eachtype do |type|
         next if type.name == :component
         next if type.name == :whit
+
         @types_hash[type.name] = type
       end
 


### PR DESCRIPTION
Previously the puppet helper only loaded the core puppet types.  This commit
instead invokes the Puppet::Util::Autoload class to load all of the puppet
types.  This means that type loading is now slower, but as it has async support
this won't stop UI requests for too long.