### PR TITLE
(GH-57) Fix bug with i18n in the language server

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -13,7 +13,11 @@ group :development do
   gem 'rspec', '>= 3.2',            :require => false
   gem "rubocop",                    :require => false, :platforms => [:ruby, :x64_mingw]
 
-  gem "puppet",                     :require => false
+  if ENV['PUPPET_GEM_VERSION']
+    gem 'puppet', ENV['PUPPET_GEM_VERSION'], :require => false
+  else
+    gem 'puppet',                            :require => false
+  end
 
   gem "win32-dir", "<= 0.4.9",      :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
   gem "win32-eventlog", "<= 0.6.5", :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]

--- a/server/lib/puppet-languageserver/document_validator.rb
+++ b/server/lib/puppet-languageserver/document_validator.rb
@@ -45,7 +45,7 @@ module PuppetLanguageServer
       Puppet[:code] = content
       env = Puppet.lookup(:current_environment)
       loaders = Puppet::Pops::Loaders.new(env)
-      Puppet.override({ :loaders => loaders }, _('For puppet parser validate')) do
+      Puppet.override({ :loaders => loaders }, 'For puppet parser validate') do
         begin
           validation_environment = env
           validation_environment.check_for_reparse

--- a/server/spec/integration/puppet-languageserver/document_validator_spec.rb
+++ b/server/spec/integration/puppet-languageserver/document_validator_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'document_validator' do
+  let(:subject) { PuppetLanguageServer::DocumentValidator }
+
+  describe '#validate' do
+    describe "Given an incomplete manifest which has syntax errors" do
+      let(:manifest) { 'user { "Bob"' }
+
+      it "should return at least one error" do
+        result = subject.validate(manifest)
+        expect(result.length).to be > 0
+      end
+    end
+
+    describe "Given a complete manifest with no validation errors" do
+      let(:manifest) { "user { 'Bob': ensure => 'present' }" }
+
+      it "should return an empty array" do
+        expect(subject.validate(manifest)).to eq([])
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Previously it was not possible to test on older puppet gems as the gemfile
always defaulted to latest.  This commit adds the PUPPET_GEM_VERSION
environment variable which can be used to set the version of the puppet gem
during a bundle.  This is the same workflow as regular Puppet modules.

The code used to do document validation was using the special function `_` which
was introduced in Puppet 4.9 for internationalisation.  This commit removes the
i18n function as it is not required for the language server itself and adds
some basic tests to prevent regression.