### PR TITLE
(GH-53) Respond to 'textDocument/didClose' notification

### DIFF
--- a/server/lib/puppet-languageserver/message_router.rb
+++ b/server/lib/puppet-languageserver/message_router.rb
@@ -131,6 +131,11 @@ module PuppetLanguageServer
         documents.set_document(file_uri, content)
         reply_diagnostics(file_uri, PuppetLanguageServer::DocumentValidator.validate(content))
 
+      when 'textDocument/didClose'
+        PuppetLanguageServer.log_message(:info, 'Received textDocument/didClose notification.')
+        file_uri = params['textDocument']['uri']
+        documents.remove_document(file_uri)
+
       when 'textDocument/didChange'
         PuppetLanguageServer.log_message(:info, 'Received textDocument/didChange notification.')
         file_uri = params['textDocument']['uri']


### PR DESCRIPTION
The didClose notification is sent when a user closes a text file in the editor.
This commit updates the language server to remove the document from the local
document store when the user closes the document.