### PR TITLE
(GH-12) Add Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,43 @@
+language: node_js
+node_js:
+  - "node"
+
+environment:
+  ELECTRON_RUN_AS_NODE: 1
+  VSCODE_BUILD_VERBOSE: true
+
+sudo: false
+
+os:
+  - linux
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.9
+      - g++-4.9
+      - gcc-4.9-multilib
+      - g++-4.9-multilib
+      - zip
+      - libgtk2.0-0
+      - libx11-dev
+      - libxkbfile-dev
+
+before_install:
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+      sh -e /etc/init.d/xvfb start;
+      sleep 3;
+    fi
+
+install:
+  - cd client
+  - npm install
+  - npm install gulp
+  - npm run vscode:prepublish
+
+script:
+  - npm test --silent
+  - gulp build


### PR DESCRIPTION
Add travis file, using https://code.visualstudio.com/docs/extensions/testing-extensions#_running-tests-automatically-on-travis-ci-build-machines as example