### PR TITLE
Fix completion at file beginning on new lines and on keywords

### DIFF
--- a/server/lib/puppet-languageserver/completion_provider.rb
+++ b/server/lib/puppet-languageserver/completion_provider.rb
@@ -4,7 +4,7 @@ module PuppetLanguageServer
       items = []
       incomplete = false
 
-      item = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num, true)
+      item = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num, true, [Puppet::Pops::Model::QualifiedName])
 
       if item.nil?
         # We are in the root of the document.

--- a/server/spec/integration/puppet-languageserver/completion_provider_spec.rb
+++ b/server/spec/integration/puppet-languageserver/completion_provider_spec.rb
@@ -36,19 +36,20 @@ EOT
       }
 
       describe "When inside the root of the manifest" do
-        let(:line_num) { 8 }
         let(:char_num) { 0 }
         let(:expected_types) { ['keyword','resource_type','function'] }
 
-        it 'should return a list of keyword, resource_type, function' do
-          result = subject.complete(content, line_num, char_num)
+        [0, 8].each do |line_num|
+          it "should return a list of keyword, resource_type, function regardless of cursor location (Testing line #{line_num})" do
+            result = subject.complete(content, line_num, char_num)
 
-          result['items'].each do |item|
-            expect(item).to be_completion_item_with_type(expected_types)
-          end
+            result['items'].each do |item|
+              expect(item).to be_completion_item_with_type(expected_types)
+            end
 
-          expected_types.each do |typename|
-            expect(number_of_completion_item_with_type(result,typename)).to be > 0
+            expected_types.each do |typename|
+              expect(number_of_completion_item_with_type(result,typename)).to be > 0
+            end
           end
         end
       end
@@ -78,6 +79,60 @@ EOT
 
         it 'should return a list of resource_parameter, resource_property' do
           result = subject.complete(content, line_num, char_num)
+
+          result['items'].each do |item|
+            expect(item).to be_completion_item_with_type(expected_types)
+          end
+
+          expected_types.each do |typename|
+            expect(number_of_completion_item_with_type(result,typename)).to be > 0
+          end
+        end
+      end
+    end
+
+    context "Given a simple manifest mid-typing" do
+      let(:content_empty) { <<-EOT
+c
+EOT
+      }
+
+      let(:content_simple) { <<-EOT
+user { 'Charlie':
+
+  ensure => 'present',
+  name   => 'name',
+}
+
+r
+EOT
+      }
+
+      describe "When typing inside the root of an empty manifest" do
+        let(:line_num) { 0 }
+        let(:char_num) { 1 }
+        let(:expected_types) { ['keyword','resource_type','function'] }
+
+        it "should return a list of keyword, resource_type, function" do
+          result = subject.complete(content_empty, line_num, char_num)
+
+          result['items'].each do |item|
+            expect(item).to be_completion_item_with_type(expected_types)
+          end
+
+          expected_types.each do |typename|
+            expect(number_of_completion_item_with_type(result,typename)).to be > 0
+          end
+        end
+      end
+
+      describe "When typing inside the root of a non-empty manifest" do
+        let(:line_num) { 6 }
+        let(:char_num) { 1 }
+        let(:expected_types) { ['keyword','resource_type','function'] }
+
+        it "should return a list of keyword, resource_type, function" do
+          result = subject.complete(content_simple, line_num, char_num)
 
           result['items'].each do |item|
             expect(item).to be_completion_item_with_type(expected_types)


### PR DESCRIPTION
I wanted to get a PR open to get some comments on it.

Changes

1. remove_char replaced by remove_word this allows users to get autocomplete if they start typing on a partial word such as "ens". Previously, they only received completion suggestions when typing a new word. remove_chars is left at the end of the list to facilitate completion of `$facts[`.
1. removed the `if abs_offset > 0` because it was preventing the start of the document from being interpreted as the root of a document, which meant no completion was being generated.
1. For completion only, added a check that the item isn't a `Puppet::Pops::Model::QualifiedName`, this always seems to be the "deepest" part of the AST if the user is typing a word, but it prevents useful autocompletion from being generated when typing at the root of the manifest.