### PR TITLE
{WIP} Use session manager to restart language server

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -3,78 +3,16 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
-import { startLangServerTCP, createLanguageServerProcess } from '../src/languageserver';
-import { setupPuppetCommands } from '../src/puppetcommands';
-
-const langID = 'puppet'; // don't change this
-var statusBarItem;
+import { SessionManager } from '../src/languageserver';
 
 export function activate(context: vscode.ExtensionContext) {
-  var myOutputChannel = vscode.window.createOutputChannel('Puppet');
-  myOutputChannel.show()
 
-  try {
-    var contextPath = context.asAbsolutePath(path.join('vendor', 'languageserver', 'puppet-languageserver'));
+  var sessionManager = new SessionManager(context);
+  sessionManager.start();
 
-    let config = vscode.workspace.getConfiguration('puppet');
-
-    var host             = config['languageserver']['address']; // '127.0.0.1';
-    var port             = config['languageserver']['port']; // 8081;
-    var stopOnClientExit = config['languageserver']['stopOnClientExit']; // true;
-    var timeout          = config['languageserver']['timeout']; // 10;
-    var preLoadPuppet    = config['languageserver']['preLoadPuppet']; // true;
-
-    createStatusBarItem();
-
-    var languageServerClient = null
-    if (host == '127.0.0.1' || host == 'localhost' || host == '') {
-      var serverProc = createLanguageServerProcess(contextPath, myOutputChannel);
-
-      serverProc.stdout.on('data', (data) => {
-        console.log("OUTPUT: " + data.toString());
-        myOutputChannel.appendLine("OUTPUT: " + data.toString());
-
-        languageServerClient = startLangServerTCP(host, port, langID, statusBarItem, myOutputChannel);
-        context.subscriptions.push(languageServerClient.start());
-      });
-
-      serverProc.on('close', (exitCode) => {
-        console.log("SERVER terminated with exit code: " + exitCode);
-        myOutputChannel.appendLine("SERVER terminated with exit code: " + exitCode);
-      });
-    }
-    else {
-      languageServerClient = startLangServerTCP(host, port, langID, statusBarItem, myOutputChannel);
-      context.subscriptions.push(languageServerClient.start());
-    }
-
-    setupPuppetCommands(langID, languageServerClient, context);
-
-    console.log('Congratulations, your extension "vscode-puppet" is now active!');
-    myOutputChannel.appendLine('Congratulations, your extension "vscode-puppet" is now active!');
-  } catch (e) {
-    console.log((<Error>e).message);//conversion to Error type
-    myOutputChannel.appendLine((<Error>e).message);
-  }
 }
 
 // this method is called when your extension is deactivated
 export function deactivate() {
 }
 
-// Status Bar handler
-export function createStatusBarItem() {
-  if (statusBarItem === undefined) {
-    // Create the status bar item and place it right next to the language indicator
-    statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 1);
-    statusBarItem.show();
-    vscode.window.onDidChangeActiveTextEditor(textEditor => {
-      if (textEditor === undefined || textEditor.document.languageId !== "puppet") {
-        statusBarItem.hide();
-      }
-      else {
-        statusBarItem.show();
-      }
-    })
-  }
-}

--- a/client/src/languageserver.ts
+++ b/client/src/languageserver.ts
@@ -8,75 +8,170 @@ import {
 } from 'vscode-languageclient'
 
 import * as messages from '../src/messages';
+import { setupPuppetCommands } from '../src/puppetcommands';
 
-export function createLanguageServerProcess(serverExe: string, myOutputChannel: vscode.OutputChannel) {
-  myOutputChannel.appendLine('Language server found at: ' + serverExe)
+const langID = 'puppet'; // don't change this
 
-  let cmd = '';
-  let args = [serverExe];
-  let options = {};
+export class SessionManager {
 
-  // type Platform = 'aix'
-  //               | 'android'
-  //               | 'darwin'
-  //               | 'freebsd'
-  //               | 'linux'
-  //               | 'openbsd'
-  //               | 'sunos'
-  //               | 'win32';
-  switch (process.platform) {
-    case 'win32':
-      myOutputChannel.appendLine('Windows spawn process does not work at the moment')
-      vscode.window.showErrorMessage('Windows spawn process does not work at the moment. Functionality will be limited to syntax highlighting');
-      break;
-    default:
-      myOutputChannel.appendLine('Starting language server')
-      cmd = 'ruby'
-      options = {
-        shell: true,
-        env: process.env,
-        stdio: 'pipe',
-      };
+  private context : vscode.ExtensionContext;
+  private outputChannel: vscode.OutputChannel;
+  private languageServerClient: LanguageClient;
+  private statusBarItem;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+
+    this.outputChannel = vscode.window.createOutputChannel('Puppet');
+    this.outputChannel.show();
+
+    this.languageServerClient = null;
+    this.statusBarItem = undefined;
   }
 
-  var proc = cp.spawn(cmd, args, options)
-  console.log("ProcID = " + proc.pid);
-  myOutputChannel.appendLine('Language server PID:' + proc.pid)
+  public start() {
+    try {
+      var contextPath = this.context.asAbsolutePath(path.join('vendor', 'languageserver', 'puppet-languageserver'));
 
-  return proc;
-}
+      let config = vscode.workspace.getConfiguration('puppet');
 
-export function startLangServerTCP(host: string, port: number, langID: string, statusBarItem, myOutputChannel): LanguageClient {
-  myOutputChannel.appendLine('Configuring language server options')
-  let serverOptions: ServerOptions = function () {
-    return new Promise((resolve, reject) => {
-      var client = new net.Socket();
-      client.connect(port, host, function () {
-        resolve({ reader: client, writer: client });
+      var host             = config['languageserver']['address']; // '127.0.0.1';
+      var port             = config['languageserver']['port']; // 8081;
+      var stopOnClientExit = config['languageserver']['stopOnClientExit']; // true;
+      var timeout          = config['languageserver']['timeout']; // 10;
+      var preLoadPuppet    = config['languageserver']['preLoadPuppet']; // true;
+
+      this.createStatusBarItem();
+
+      if (host == '127.0.0.1' || host == 'localhost' || host == '') {
+        var serverProc = this.createLanguageServerProcess(contextPath);
+
+        serverProc.stdout.on('data', (data) => {
+          console.log("OUTPUT: " + data.toString());
+          this.outputChannel.appendLine("OUTPUT: " + data.toString());
+
+          this.startLangServerTCP(host, port);
+          this.context.subscriptions.push(this.languageServerClient.start());
+        });
+
+        serverProc.on('close', (exitCode) => {
+          console.log("SERVER terminated with exit code: " + exitCode);
+          this.outputChannel.appendLine("SERVER terminated with exit code: " + exitCode);
+        });
+      }
+      else {
+        this.startLangServerTCP(host, port);
+        this.context.subscriptions.push(this.languageServerClient.start());
+      }
+
+      setupPuppetCommands(langID, this.languageServerClient, this.context);
+
+      console.log('Congratulations, your extension "vscode-puppet" is now active!');
+      this.outputChannel.appendLine('Congratulations, your extension "vscode-puppet" is now active!');
+    } catch (e) {
+      console.log((<Error>e).message);//conversion to Error type
+      this.outputChannel.appendLine((<Error>e).message);
+    }
+  }
+
+  private createLanguageServerProcess(serverExe: string) {
+    this.outputChannel.appendLine('Language server found at: ' + serverExe)
+
+    let cmd = '';
+    let args = [serverExe];
+    let options = {};
+
+    // type Platform = 'aix'
+    //               | 'android'
+    //               | 'darwin'
+    //               | 'freebsd'
+    //               | 'linux'
+    //               | 'openbsd'
+    //               | 'sunos'
+    //               | 'win32';
+    switch (process.platform) {
+      case 'win32':
+        this.outputChannel.appendLine('Windows spawn process does not work at the moment')
+        vscode.window.showErrorMessage('Windows spawn process does not work at the moment. Functionality will be limited to syntax highlighting');
+        break;
+      default:
+        this.outputChannel.appendLine('Starting language server')
+        cmd = 'ruby'
+        options = {
+          shell: true,
+          env: process.env,
+          stdio: 'pipe',
+        };
+    }
+
+    var proc = cp.spawn(cmd, args, options)
+    console.log("ProcID = " + proc.pid);
+    this.outputChannel.appendLine('Language server PID:' + proc.pid)
+
+    return proc;
+  }
+
+  private startLangServerTCP(host: string, port: number) {
+    this.outputChannel.appendLine('Configuring language server options')
+    let serverOptions: ServerOptions = () => {
+      return new Promise((resolve, reject) => {
+        var client = new net.Socket();
+        client.connect(port, host, function () {
+          resolve({ reader: client, writer: client });
+        });
+        client.on('error', (err) => {
+          console.log(`[Puppet Lang Server Client] ` + err);
+          this.promptForRestart();
+        })
       });
-      client.on('error', function (err) {
-        console.log(`[Puppet Lang Server Client] ` + err);
+    }
+
+    this.outputChannel.appendLine('Configuring language server client options')
+    let clientOptions: LanguageClientOptions = {
+      documentSelector: [langID],
+    }
+
+    this.outputChannel.appendLine('Starting language server client')
+    var title = `tcp lang server (host ${host} port ${port})`;
+    this.languageServerClient = new LanguageClient(title, serverOptions, clientOptions)
+    this.languageServerClient.onReady().then(() => {
+      this.outputChannel.appendLine('Language server client started, setting puppet version')
+      this.languageServerClient.sendRequest(messages.PuppetVersionRequest.type).then((versionDetails) => {
+        this.statusBarItem.color = "#affc74";
+        this.statusBarItem.text = "$(terminal) " + versionDetails.puppetVersion;
+      });
+    }, (reason) => {
+      this.outputChannel.appendLine("Could not start language service: " + reason);
+    });
+  }
+
+  private createStatusBarItem() {
+    if (this.statusBarItem === undefined) {
+      // Create the status bar item and place it right next to the language indicator
+      this.statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 1);
+      this.statusBarItem.show();
+      vscode.window.onDidChangeActiveTextEditor(textEditor => {
+        if (textEditor === undefined || textEditor.document.languageId !== "puppet") {
+          this.statusBarItem.hide();
+        }
+        else {
+          this.statusBarItem.show();
+        }
       })
-    });
+    }
   }
 
-  myOutputChannel.appendLine('Configuring language server client options')
-  let clientOptions: LanguageClientOptions = {
-    documentSelector: [langID],
+  private restartSession() {
+    this.languageServerClient = null;
+    this.statusBarItem = undefined;
+
+    this.start();
   }
 
-  myOutputChannel.appendLine('Starting language server client')
-  var title = `tcp lang server (host ${host} port ${port})`;
-  var languageServerClient = new LanguageClient(title, serverOptions, clientOptions)
-  languageServerClient.onReady().then(() => {
-    myOutputChannel.appendLine('Language server client started, setting puppet version')
-    languageServerClient.sendRequest(messages.PuppetVersionRequest.type).then((versionDetails) => {
-      statusBarItem.color = "#affc74";
-      statusBarItem.text = "$(terminal) " + versionDetails.puppetVersion;
-    });
-  }, (reason) => {
-    this.setSessionFailure("Could not start language service: ", reason);
-  });
-
-  return languageServerClient;
+  private promptForRestart() {
+    vscode.window.showErrorMessage(
+      "The Puppet Language Server session has terminated due to an error, would you like to restart it?",
+      "Yes", "No")
+      .then((answer) => { if (answer === "Yes") { this.restartSession(); }});
+    }
 }


### PR DESCRIPTION
## Todo
Don't recreate the following on restart

- [ ] Commands
- [ ] StatusBar

## Pondering UX details

This will currently catch any failure to connect, are there some we want to fail and not prompt for restart now? If it tries to connect to a pre-made language server and fails should we offer to try to spin one up locally?