### PR TITLE
Add better puppet-agent detection

### DIFF
--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -209,7 +209,13 @@ export class ConnectionManager implements IConnectionManager {
         break;
       default:
         myOutputChannel.appendLine('Starting language server')
-        cmd = 'ruby'
+
+        // Try and find the puppet-agent ruby
+        let rubyPath: string = '/opt/puppetlabs/puppet/bin/ruby';
+        if (fs.existsSync(rubyPath)) { cmd = rubyPath }
+
+        // Default to ruby on the path
+        if (cmd == undefined) { cmd = 'ruby' }
         options = {
           shell: true,
           env: process.env,


### PR DESCRIPTION
Previously the default behaviour was to use ruby in the path however some puppet
agent installations do not put its ruby on the path and is instead located in
/opt/puppetlabs/puppet/bin/ruby. This commit adds file detection to prefer the
specific puppet agent location of ruby and fall back to just the path.