### PR TITLE
Fix packaging JSON and appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,4 @@
 version: 0.0.4-appv.{build}
-branches:
-  only:
-  - add-travis-appveyor
-  - language-server-feature
 clone_depth: 10
 init:
 - SET

--- a/client/package.json
+++ b/client/package.json
@@ -118,7 +118,6 @@
   "devDependencies": {
     "typescript": "^2.0.3",
     "vscode": "^1.0.0",
-    "vscode-languageclient": "^3.1.0",
     "vsce": "^1.18.0",
     "gulp": "^3.9.1",
     "gulp-bump": "^2.7.0",
@@ -129,6 +128,6 @@
     "@types/mocha": "^2.2.32"
   },
   "dependencies": {
-    "vscode-languageserver": "^3.1.0"
+    "vscode-languageclient": "^3.1.0"
   }
 }


### PR DESCRIPTION
Previously the dependency was using language server, however the actual
dependency should be languageclient which causes the packaged extension to fail
to start.  This commit changes the dependency to be languageclient.