### PR TITLE
Allow Puppet 5.0 tests to fail

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,11 @@ environment:
     RUBY_VER: 21-x64
     RAKE_TASK: test
   # Latest Puppet
-  - PUPPET_GEM_VERSION: "> 4.0.0"
-    RUBY_VER: 23-x64
+  - PUPPET_GEM_VERSION: "~> 5.0"
+    RUBY_VER: 24-x64
     RAKE_TASK: test
   # Ruby style
-  - PUPPET_GEM_VERSION: "> 4.0.0"
+  - PUPPET_GEM_VERSION: "~> 4.0"
     RUBY_VER: 23-x64
     RAKE_TASK: rubocop
 
@@ -33,9 +33,13 @@ matrix:
   fast_finish: true
   allow_failures:
     # Ruby style
-    - PUPPET_GEM_VERSION: "> 4.0.0"
+    - PUPPET_GEM_VERSION: "~> 4.0"
       RUBY_VER: 23-x64
       RAKE_TASK: rubocop
+    # Latest Puppet
+    - PUPPET_GEM_VERSION: "~> 5.0"
+      RUBY_VER: 24-x64
+      RAKE_TASK: test
 
 install:
 - ps: |


### PR DESCRIPTION
With the release of Puppet 5 gem, the tests are failing due to breaking changes
in the parser/lexing APIs.  This commit modifies the Appveyor matrix to pin to
latest version of Puppet 4 for testing and optionally fail when testing on
Puppet 5