### PR TITLE
(GH-103) Parse /etc and ~/ config files

### DIFF
--- a/server/lib/puppet-languageserver/document_validator.rb
+++ b/server/lib/puppet-languageserver/document_validator.rb
@@ -7,6 +7,8 @@ module PuppetLanguageServer
       problems = 0
 
       begin
+        # TODO: load .puppet-lint.rc from the module root as well
+        PuppetLint::OptParser.build
         linter = PuppetLint::Checks.new
         problems = linter.run(nil, content)
         unless problems.nil?


### PR DESCRIPTION
Fixes #103. This is a partial fix, we cannot parse .puppet-lint.rc files
from the module root until we have a concept of module in the extension.