### PR TITLE
(GH-52) Add JSON schema for metadata.json

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -20,6 +20,7 @@ This extension provides full Puppet Language support for [Visual Studio Code](ht
 - [Syntax highlighting](#Syntax_Highlighting)
 - [Code snippets](#Code_snippets)
 - IntelliSense for resources, parameters and more
+- Validation of `metadata.json` files
 - Import from `puppet resource` directly into manifests
 - Node graph preview
 
@@ -42,6 +43,7 @@ Syntax highlighting uses [puppet-lint](https://github.com/rodjek/puppet-lint) an
 
 - Puppet DSL
 - Puppet Grammar
+- Module metadata files
 
 ### Code Snippets
 

--- a/client/package.json
+++ b/client/package.json
@@ -25,7 +25,8 @@
     "categories": [
         "Linters",
         "Languages",
-        "Snippets"
+        "Snippets",
+        "Formatters"
     ],
     "keywords": [
         "puppet",
@@ -57,6 +58,10 @@
                 "configuration": "./languages/puppet.configuration.json"
             }
         ],
+        "jsonValidation": [{
+            "fileMatch": "metadata.json",
+            "url": "./src/metadata-json-schema.json"
+        }],
         "grammars": [
             {
                 "language": "puppet",
@@ -68,6 +73,10 @@
             {
                 "language": "puppet",
                 "path": "./snippets/keywords.snippets.json"
+            },
+            {
+                "language": "json",
+                "path": "./snippets/metadata.snippets.json"
             }
         ],
         "commands": [

--- a/client/snippets/metadata.snippets.json
+++ b/client/snippets/metadata.snippets.json
@@ -1,0 +1,20 @@
+{
+  "blank metadata.json": {
+    "prefix": "metadata.json",
+    "body": [
+      "{",
+      "  \"name\": \"${1:author}-${2:module_name}\",",
+      "  \"version\": \"0.1.0\",",
+      "  \"author\": \"$1\",",
+      "  \"summary\": \"${3:brief summary}\",",
+      "  \"license\": \"Apache-2.0\",",
+      "  \"source\": \"${4:source location of the module}\",",
+      "  \"dependencies\": [",
+      "    {\"name\":\"puppetlabs-stdlib\",\"version_requirement\":\">= 1.0.0\"}",
+      "  ]",
+      "}",
+      ""
+    ],
+    "description": "Empty metadata.json file"
+  }
+}

--- a/client/src/metadata-json-schema.json
+++ b/client/src/metadata-json-schema.json
@@ -1,0 +1,173 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "puppet-module-metadata",
+  "type": "object",
+  "description": "Puppet Module metadata.json Schema https://docs.puppet.com/puppet/latest/modules_metadata.html",
+  "properties": {
+    "name": {
+      "description": "The full name of your module, including the Puppet Forge username", 
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9]+[-][a-z][a-z0-9_]*$"
+    },
+    "version": {
+      "description": "The current version of your module. This should follow semantic versioning",
+      "type": "string",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(-(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(\\.(0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\\+[0-9a-zA-Z-]+(\\.[0-9a-zA-Z-]+)*)?$"
+    },
+    "author": {
+      "description": "The person who gets credit for creating the module",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "[a-zA-Z0-9]+"
+    },
+    "license": {
+      "description": "The license under which your module is made available. License metadata should match an identifier provided by SPDX",
+      "type": "string",
+      "enum": [
+        "Glide","Abstyles","AFL-1.1","AFL-1.2",
+        "AFL-2.0","AFL-2.1","AFL-3.0","AMPAS","APL-1.0","Adobe-Glyph","APAFML","Adobe-2006","AGPL-1.0","Afmparse","Aladdin","ADSL","AMDPLPA","ANTLR-PD","Apache-1.0","Apache-1.1","Apache-2.0","AML","APSL-1.0",
+        "APSL-1.1","APSL-1.2","APSL-2.0","Artistic-1.0","Artistic-1.0-Perl","Artistic-1.0-cl8","Artistic-2.0","AAL","Bahyph","Barr","Beerware","BitTorrent-1.0","BitTorrent-1.1","BSL-1.0","Borceux","BSD-2-Clause",
+        "BSD-2-Clause-FreeBSD","BSD-2-Clause-NetBSD","BSD-3-Clause","BSD-3-Clause-Clear","BSD-3-Clause-No-Nuclear-License","BSD-3-Clause-No-Nuclear-License-2014","BSD-3-Clause-No-Nuclear-Warranty",
+        "BSD-4-Clause","BSD-Protection","BSD-Source-Code","BSD-3-Clause-Attribution","0BSD","BSD-4-Clause-UC","bzip2-1.0.5","bzip2-1.0.6","Caldera","CECILL-1.0","CECILL-1.1","CECILL-2.0","CECILL-2.1","CECILL-B",
+        "CECILL-C","ClArtistic","MIT-CMU","CNRI-Jython","CNRI-Python","CNRI-Python-GPL-Compatible","CPOL-1.02","CDDL-1.0","CDDL-1.1","CPAL-1.0","CPL-1.0","CATOSL-1.1","Condor-1.1","CC-BY-1.0","CC-BY-2.0",
+        "CC-BY-2.5","CC-BY-3.0","CC-BY-4.0","CC-BY-ND-1.0","CC-BY-ND-2.0","CC-BY-ND-2.5","CC-BY-ND-3.0","CC-BY-ND-4.0","CC-BY-NC-1.0","CC-BY-NC-2.0","CC-BY-NC-2.5","CC-BY-NC-3.0","CC-BY-NC-4.0","CC-BY-NC-ND-1.0",
+        "CC-BY-NC-ND-2.0","CC-BY-NC-ND-2.5","CC-BY-NC-ND-3.0","CC-BY-NC-ND-4.0","CC-BY-NC-SA-1.0","CC-BY-NC-SA-2.0","CC-BY-NC-SA-2.5","CC-BY-NC-SA-3.0","CC-BY-NC-SA-4.0","CC-BY-SA-1.0","CC-BY-SA-2.0","CC-BY-SA-2.5",
+        "CC-BY-SA-3.0","CC-BY-SA-4.0","CC0-1.0","Crossword","CrystalStacker","CUA-OPL-1.0","Cube","curl","D-FSL-1.0","diffmark","WTFPL","DOC","Dotseqn","DSDP","dvipdfm","EPL-1.0","ECL-1.0","ECL-2.0","eGenix",
+        "EFL-1.0","EFL-2.0","MIT-advertising","MIT-enna","Entessa","ErlPL-1.1","EUDatagrid","EUPL-1.0","EUPL-1.1","Eurosym","Fair","MIT-feh","Frameworx-1.0","FreeImage","FTL","FSFAP","FSFUL","FSFULLR","Giftware",
+        "GL2PS","Glulxe","AGPL-3.0","GFDL-1.1","GFDL-1.2","GFDL-1.3","GPL-1.0","GPL-2.0","GPL-3.0","LGPL-2.1","LGPL-3.0","LGPL-2.0","gnuplot","gSOAP-1.3b","HaskellReport","HPND","IBM-pibs","IPL-1.0","ICU",
+        "ImageMagick","iMatix","Imlib2","IJG","Info-ZIP","Intel-ACPI","Intel","Interbase-1.0","IPA","ISC","JasPer-2.0","JSON","LPPL-1.0","LPPL-1.1","LPPL-1.2","LPPL-1.3a","LPPL-1.3c","Latex2e","BSD-3-Clause-LBNL",
+        "Leptonica","LGPLLR","Libpng","libtiff","LAL-1.2","LAL-1.3","LiLiQ-P-1.1","LiLiQ-Rplus-1.1","LiLiQ-R-1.1","LPL-1.02","LPL-1.0","MakeIndex","MTLL","MS-PL","MS-RL","MirOS","MITNFA","MIT","Motosoto",
+        "MPL-1.0","MPL-1.1","MPL-2.0","MPL-2.0-no-copyleft-exception","mpich2","Multics","Mup","NASA-1.3","Naumen","NBPL-1.0","Net-SNMP","NetCDF","NGPL","NOSL","NPL-1.0","NPL-1.1","Newsletr","NLPL","Nokia",
+        "NPOSL-3.0","NLOD-1.0","Noweb","NRL","NTP","Nunit","OCLC-2.0","ODbL-1.0","proprietary","PDDL-1.0","OCCT-PL","OGTSL","OLDAP-2.2.2","OLDAP-1.1","OLDAP-1.2","OLDAP-1.3","OLDAP-1.4","OLDAP-2.0","OLDAP-2.0.1","OLDAP-2.1",
+        "OLDAP-2.2","OLDAP-2.2.1","OLDAP-2.3","OLDAP-2.4","OLDAP-2.5","OLDAP-2.6","OLDAP-2.7","OLDAP-2.8","OML","OPL-1.0","OSL-1.0","OSL-1.1","OSL-2.0","OSL-2.1","OSL-3.0","OpenSSL","OSET-PL-2.1",
+        "PHP-3.0","PHP-3.01","Plexus","PostgreSQL","psfrag","psutils","Python-2.0","QPL-1.0","Qhull","Rdisc","RPSL-1.0","RPL-1.1","RPL-1.5","RHeCos-1.1","RSCPL","RSA-MD","Ruby","SAX-PD","Saxpath","SCEA","SWL",
+        "SMPPL","Sendmail","SGI-B-1.0","SGI-B-1.1","SGI-B-2.0","OFL-1.0","OFL-1.1","SimPL-2.0","Sleepycat","SNIA","Spencer-86","Spencer-94","Spencer-99","SMLNJ","SugarCRM-1.1.3","SISSL","SISSL-1.2","SPL-1.0",
+        "Watcom-1.0","TCL","TCP-wrappers","Unlicense","TMate","TORQUE-1.1","TOSL","Unicode-DFS-2015","Unicode-DFS-2016","Unicode-TOU","UPL-1.0","NCSA","Vim","VOSTROM","VSL-1.0","W3C-20150513","W3C-19980720",
+        "W3C","Wsuipa","Xnet","X11","Xerox","XFree86-1.1","xinetd","xpp","XSkat","YPL-1.0","YPL-1.1","Zed","Zend-2.0","Zimbra-1.3","Zimbra-1.4","Zlib","zlib-acknowledgement","ZPL-1.1","ZPL-2.0","ZPL-2.1"
+      ],
+      "default": "Apache-2.0"
+    },
+    "summary": {
+      "description": "A one-line description of your module",
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "description": "The source repository for your module",
+      "type": "string",
+      "minLength": 1
+    },
+    "dependencies": {
+      "description": "A list of modules that this module depends on",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/module_dependency"
+      },
+      "uniqueItems": true
+    },
+    "requirements": {
+      "description": "A list of requirements that this module needs",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/module_requirement"
+      },
+      "uniqueItems": true
+    },
+    "project_page": {
+      "description": "A link to your module's website to be included on the Forge",
+      "type": "string",
+      "format": "uri"
+    },
+    "issues_url": {
+      "description": "A link to your module's issue tracker",
+      "type": "string",
+      "format": "uri"
+    },
+    "operatingsystem_support": {
+      "description": "A list of operating systems that this module supports",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/module_operating_system"
+      },
+      "uniqueItems": true
+    },
+    "tags": {
+      "description": "A list of tags that would categorize this module",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    }
+  },
+  "required": [
+    "name",
+    "version",
+    "author",
+    "license",
+    "summary",
+    "source",
+    "dependencies"
+  ],
+  "additionalProperties": false,
+
+  "definitions": {
+    "module_dependency": {
+      "properties": {
+        "name": {
+          "description": "Name of the dependent module",
+          "type":"string",
+          "minLength": 1
+        },
+        "version_requirement": {
+          "description": "Version specification for the dependent module",
+          "type":"string",
+          "minLength": 1
+        }
+      },
+      "required": ["name","version_requirement"],
+      "additionalProperties": false
+    },
+    "module_requirement": {
+      "properties": {
+        "name": {
+          "description": "Name of the requirement. 'pe' is deprecated ",
+          "type":"string",
+          "minLength": 1,
+          "pattern": "^((?!^pe$).)*$"
+        },
+        "version_requirement": {
+          "description": "Version specification for the requirement",
+          "type":"string",
+          "minLength": 1
+        }
+      },
+      "required": ["name","version_requirement"],
+      "additionalProperties": false
+    },
+    "module_operating_system": {
+      "properties": {
+        "operatingsystem": {
+          "description": "Name of the operating system family, for example 'redhat' or 'windows'",
+          "type":"string",
+          "minLength": 1
+        },
+        "operatingsystemrelease": {
+          "description": "Version specification for the dependent module",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      },
+      "required": ["operatingsystem"],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a JSON schema document for metadata.json and applies it to any
file with the name metadata.json.  This commit also adds a snippet for any JSON
file to insert a full but blank metadata.json file with a some interactive
editting.

- [x] Add validator
- [x] Update docs and extension metadata