### PR TITLE
(GH-103) Parse puppet-lint.rc in module directory

### DIFF
--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -224,6 +224,7 @@ export class ConnectionManager implements IConnectionManager {
 
     if ((this.connectionConfiguration.host == undefined) || (this.connectionConfiguration.host == '')) {
       args.push('--ip=127.0.0.1');
+      args.push('--local-workspace=' + vscode.workspace.textDocuments[0]);
     } else {
       args.push('--ip=' + this.connectionConfiguration.host);
     }

--- a/server/lib/puppet-languageserver.rb
+++ b/server/lib/puppet-languageserver.rb
@@ -24,7 +24,8 @@ module PuppetLanguageServer
         connection_timeout: 10,
         preload_puppet: true,
         debug: nil,
-        fast_start_tcpserver: true
+        fast_start_tcpserver: true,
+        workspace: nil,
       }
 
       opt_parser = OptionParser.new do |opts|
@@ -56,6 +57,10 @@ module PuppetLanguageServer
 
         opts.on('-s', '--slow-start', 'Delay starting the TCP Server until Puppet initialisation has completed.  Default is to start fast') do |_misc|
           args[:fast_start_tcpserver] = false
+        end
+
+        opts.on('--local-workspace=PATH', 'The workspace or file path that will be used to provide module-specific functionality. Default is no workspace path.') do |path|
+          args[:workspace] = path
         end
 
         opts.on('-h', '--help', 'Prints this help') do

--- a/server/lib/puppet-languageserver/message_router.rb
+++ b/server/lib/puppet-languageserver/message_router.rb
@@ -24,6 +24,8 @@ module PuppetLanguageServer
   class MessageRouter < JSONRPCHandler
     def initialize(*options)
       super(*options)
+
+      @workspace = options.first[:workspace] unless options.compact.empty?
     end
 
     def documents
@@ -139,7 +141,7 @@ module PuppetLanguageServer
         file_uri = params['textDocument']['uri']
         content = params['textDocument']['text']
         documents.set_document(file_uri, content)
-        reply_diagnostics(file_uri, PuppetLanguageServer::DocumentValidator.validate(content))
+        reply_diagnostics(file_uri, PuppetLanguageServer::DocumentValidator.validate(content, @workspace))
 
       when 'textDocument/didClose'
         PuppetLanguageServer.log_message(:info, 'Received textDocument/didClose notification.')
@@ -151,7 +153,7 @@ module PuppetLanguageServer
         file_uri = params['textDocument']['uri']
         content = params['contentChanges'][0]['text'] # TODO: Bad hardcoding zero
         documents.set_document(file_uri, content)
-        reply_diagnostics(file_uri, PuppetLanguageServer::DocumentValidator.validate(content))
+        reply_diagnostics(file_uri, PuppetLanguageServer::DocumentValidator.validate(content, @workspace))
 
       when 'textDocument/didSave'
         PuppetLanguageServer.log_message(:info, 'Received textDocument/didSave notification.')

--- a/server/spec/integration/puppet-languageserver/document_validator_spec.rb
+++ b/server/spec/integration/puppet-languageserver/document_validator_spec.rb
@@ -8,7 +8,7 @@ describe 'document_validator' do
       let(:manifest) { 'user { "Bob"' }
 
       it "should return at least one error" do
-        result = subject.validate(manifest)
+        result = subject.validate(manifest, nil)
         expect(result.length).to be > 0
       end
     end
@@ -17,7 +17,7 @@ describe 'document_validator' do
       let(:manifest) { "user { 'Bob': ensure => 'present' }" }
 
       it "should return an empty array" do
-        expect(subject.validate(manifest)).to eq([])
+        expect(subject.validate(manifest, nil)).to eq([])
       end
     end
 


### PR DESCRIPTION
This adds the ability for a module-level .puppet-lint.rc file to be
honored by the language server, when the language server is started
locally with --local-workspace=PATH command

Fixes #103.