### PR TITLE
adds basic PDK support

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -5,3 +5,4 @@ tmp/
 
 // Ignore generated module output
 *.vsix
+.vscode-test

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -6,11 +6,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
-## 0.6.1
-
+* Added support for the PDK(https://puppet.com/blog/develop-modules-faster-new-puppet-development-kit)
 * Added telemetry to understand which parts Puppet users find useful. This will help us refine which commands we add in the future. We track whether the following commands are executed:
-  * `foo`
-  * `bar`
+  * `puppet resource`
+  * `pdk new module`
+  * `pdk new class`
+  * `pdk validate`
+  * `pdk test unit`
 
 > Please` note, you can turn off telemetry reporting for VS Code and all extensions through the ["telemetry.enableTelemetry": false setting](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
 

--- a/client/README.md
+++ b/client/README.md
@@ -38,6 +38,7 @@ Open any Puppet manifest with the extension '.pp' or 'epp' and the extension wil
 - Validation of `metadata.json` files
 - Import from `puppet resource` directly into manifests
 - Node graph preview
+- Puppet Development Kit integration
 
 ## Feature information
 
@@ -76,6 +77,21 @@ You can preview the [node graph](https://puppet.com/blog/visualize-your-infrastr
 2. Type `puppet open node`.. and press enter
 
 The node graph will appear next to the manifest
+
+### Puppet Development Kit
+
+You can use the [Puppet Development Kit](https://puppet.com/blog/develop-modules-faster-new-puppet-development-kit) inside VS Code from the command palette.
+
+** Note: The PDK must be installed prior to using these commands
+
+The following commands are supported:
+
+- pdk new module
+- pdk new class
+- pdk validate
+- pdk test unit
+
+To use any of the above commands, open the command palette and start typing a command. You can also use the right-click context menu or the editor menu to reach these commands.
 
 ## Installing the Extension
 
@@ -117,3 +133,4 @@ This extension collects telemetry data to help us build a better experience for 
 ## License
 
 This extension is [licensed under the Apache-2.0 License](LICENSE.txt).
+

--- a/client/images/puppet_logo_sm.svg
+++ b/client/images/puppet_logo_sm.svg
@@ -1,0 +1,5 @@
+<svg 
+  xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <title>file_type_puppet</title>
+  <path d="M25.089,11.822H18.7L15.267,8.388V2H6.911v8.357H13.3l3.422,3.422h0v4.431h0l-3.434,3.434H6.911V30h8.357V23.612h0L18.7,20.178h6.388ZM9.7,4.786h2.786V7.571H9.7ZM12.482,27.2H9.7V24.417h2.786Z" style="fill:#ffae1a"/>
+</svg>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -937,7 +937,7 @@
                 "expand-tilde": "2.0.2",
                 "is-plain-object": "2.0.4",
                 "object.defaults": "1.1.0",
-                "object.pick": "1.2.0",
+                "object.pick": "1.3.0",
                 "parse-filepath": "1.0.1"
             },
             "dependencies": {
@@ -1325,7 +1325,7 @@
                 "chalk": "1.1.3",
                 "deprecated": "0.0.1",
                 "gulp-util": "3.0.8",
-                "interpret": "1.0.3",
+                "interpret": "1.0.4",
                 "liftoff": "2.3.0",
                 "minimist": "1.2.0",
                 "orchestrator": "0.3.8",
@@ -2225,9 +2225,9 @@
             "dev": true
         },
         "interpret": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-            "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+            "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
             "dev": true
         },
         "invert-kv": {
@@ -3270,12 +3270,20 @@
             }
         },
         "object.pick": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
-            "integrity": "sha1-tTkr7peC2m2ft9avr1OXefEjTCs=",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "2.1.0"
+                "isobject": "3.0.1"
+            },
+            "dependencies": {
+                "isobject": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+                    "dev": true
+                }
             }
         },
         "once": {

--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,11 @@
         "onCommand:extension.puppetLint",
         "onCommand:extension.puppetParserValidate",
         "onCommand:extension.puppetShowNodeGraphToSide",
-        "onCommand:extension.puppetResource"
+        "onCommand:extension.puppetResource",
+        "onCommand:extension.pdkNewModule",
+        "onCommand:extension.pdkNewClass",
+        "onCommand:extension.pdkTestUnit",
+        "onCommand:extension.pdkValidate"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -84,10 +88,33 @@
         ],
         "commands": [
             {
+                "command": "extension.pdkNewModule",
+                "category": "Puppet",
+                "title": "PDK New Module",
+                "icon": {
+                    "dark": "images/puppet_logo_sm.svg",
+                    "light": "images/puppet_logo_sm.svg"
+                }
+            },
+            {
+                "command": "extension.pdkTestUnit",
+                "category": "Puppet",
+                "title": "PDK Test Unit"
+            },
+            {
+                "command": "extension.pdkValidate",
+                "category": "Puppet",
+                "title": "PDK Validate"
+            },
+            {
+                "command": "extension.pdkNewClass",
+                "category": "Puppet",
+                "title": "PDK New Class"
+            },
+            {
                 "command": "extension.puppetResource",
                 "category": "Puppet",
-                "title": "Puppet Resource",
-                "when": "editorTextFocus && editorLangId == 'puppet'"
+                "title": "Puppet Resource"
             },
             {
                 "command": "extension.puppetShowNodeGraphToSide",
@@ -100,24 +127,87 @@
             }
         ],
         "menus": {
+            "commandPalette": [
+                {
+                    "command": "extension.pdkNewModule"
+                },
+                {
+                    "command": "extension.pdkTestUnit",
+                    "when": "resourceLangId == 'puppet'"
+                },
+                {
+                    "command": "extension.pdkValidate",
+                    "when": "resourceLangId == 'puppet'"
+                },
+                {
+                    "command": "extension.pdkNewClass",
+                    "when": "resourceLangId == 'puppet'"
+                },
+                {
+                    "command": "extension.puppetResource",
+                    "when": "editorTextFocus && editorLangId == 'puppet'"
+                },
+                {
+                    "command": "extension.puppetShowNodeGraphToSide",
+                    "when": "resourceLangId == 'puppet'"
+                }
+            ],
             "editor/title": [
+                {
+                    "command": "extension.pdkNewModule",
+                    "group": "navigation@100"
+                },
+                {
+                    "when": "resourceLangId == 'puppet'",
+                    "command": "extension.pdkNewClass",
+                    "group": "pdk@2"
+                },
+                {
+                    "when": "resourceLangId == 'puppet' ",
+                    "command": "extension.pdkValidate",
+                    "group": "pdk@3"
+                },
+                {
+                    "when": "resourceLangId == 'puppet'",
+                    "command": "extension.pdkTestUnit",
+                    "group": "pdk@4"
+                },
                 {
                     "when": "resourceLangId == 'puppet'",
                     "command": "extension.puppetShowNodeGraphToSide",
-                    "alt": "extension.puppetShowNodeGraphToSide"
+                    "group": "puppet"
+                },
+                {
+                    "when": "resourceLangId == 'puppet'",
+                    "command": "extension.puppetResource",
+                    "group": "puppet"
                 }
             ],
             "editor/context": [
                 {
                     "when": "resourceLangId == 'puppet'",
+                    "command": "extension.pdkNewClass",
+                    "group": "pdk@1"
+                },
+                {
+                    "when": "resourceLangId == 'puppet'",
+                    "command": "extension.pdkValidate",
+                    "group": "pdk@2"
+                },
+                {
+                    "when": "resourceLangId == 'puppet'",
+                    "command": "extension.pdkTestUnit",
+                    "group": "pdk@3"
+                },
+                {
+                    "when": "resourceLangId == 'puppet'",
                     "command": "extension.puppetShowNodeGraphToSide",
-                    "alt": "extension.puppetShowNodeGraphToSide"
+                    "group": "puppet"
                 },
                 {
                     "when": "resourceLangId == 'puppet'",
                     "command": "extension.puppetResource",
-                    "alt": "extension.puppetResource",
-                    "group": ""
+                    "group": "puppet"
                 }
             ]
         },
@@ -168,9 +258,9 @@
                     "description": "Set the minimum log level that the user will see on the Puppet OutputChannel (Allowed values: verbose, debug, normal, warning, error)"
                 },
                 "puppet.puppetAgentDir": {
-                  "type": "string",
-                  "default": "normal",
-                  "description": "The fully qualified path to the Puppet agent install directory. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'"
+                    "type": "string",
+                    "default": "normal",
+                    "description": "The fully qualified path to the Puppet agent install directory. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'"
                 }
             }
         }
@@ -183,16 +273,16 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "typescript": "^2.0.3",
-        "vscode": "^1.0.0",
-        "vsce": "^1.18.0",
+        "@types/mocha": "^2.2.32",
+        "@types/node": "^6.0.40",
+        "del": "^2.2.2",
         "gulp": "^3.9.1",
         "gulp-bump": "^2.7.0",
-        "yargs": "^8.0.1",
-        "del": "^2.2.2",
         "run-sequence": "^1.2.2",
-        "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
+        "typescript": "^2.0.3",
+        "vsce": "^1.18.0",
+        "vscode": "^1.0.0",
+        "yargs": "^8.0.1"
     },
     "dependencies": {
         "vscode-languageclient": "~3.3.0",

--- a/client/src/commands/pdk/pdkNewClassCommand.ts
+++ b/client/src/commands/pdk/pdkNewClassCommand.ts
@@ -1,0 +1,40 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import ChildProcess = cp.ChildProcess;
+import { Logger } from '../../logging';
+import { reporter } from '../../telemetry/telemetry';
+import * as messages from '../../messages';
+
+export class pdkNewClassCommand {
+  private logger: Logger = undefined;
+  private terminal: vscode.Terminal = undefined;
+
+  constructor(logger: Logger, terminal: vscode.Terminal) {
+    this.logger = logger;
+    this.terminal = terminal;
+  }
+
+  public run() {
+    let nameOpts: vscode.QuickPickOptions = {
+      placeHolder: "Enter a name for the new Puppet class",
+      matchOnDescription: true,
+      matchOnDetail: true
+    };
+    vscode.window.showInputBox(nameOpts).then(moduleName => {
+      this.terminal.sendText(`pdk new class ${moduleName}`);
+      this.terminal.show();
+      if (reporter) {
+        reporter.sendTelemetryEvent('command', {
+          command: messages.PDKCommandStrings.PdkNewClassCommandId
+        });
+      }
+    })
+  }
+
+  public dispose(): any {
+    this.terminal.dispose();
+    this.terminal = undefined;
+  }
+}

--- a/client/src/commands/pdk/pdkNewModuleCommand.ts
+++ b/client/src/commands/pdk/pdkNewModuleCommand.ts
@@ -1,0 +1,51 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import { Logger } from '../../logging';
+import { reporter } from '../../telemetry/telemetry';
+import * as messages from '../../messages';
+
+export class pdkNewModuleCommand {
+  private logger: Logger = undefined;
+  private terminal: vscode.Terminal = undefined;
+
+  constructor(logger: Logger, terminal: vscode.Terminal) {
+    this.logger = logger;
+    this.terminal = terminal;
+  }
+
+  public run() {
+    let nameOpts: vscode.QuickPickOptions = {
+      placeHolder: "Enter a name for the new Puppet module",
+      matchOnDescription: true,
+      matchOnDetail: true
+    };
+    let dirOpts: vscode.QuickPickOptions = {
+      placeHolder: "Enter a path for the new Puppet module",
+      matchOnDescription: true,
+      matchOnDetail: true
+    };
+
+    vscode.window.showInputBox(nameOpts).then(moduleName => {
+      if (moduleName == undefined) {
+        vscode.window.showWarningMessage('No module name specifed. Exiting.')
+        return;
+      }
+      vscode.window.showInputBox(dirOpts).then(dir => {
+        this.terminal.sendText(`pdk new module --skip-interview ${moduleName} ${dir}`);
+        this.terminal.sendText(`code ${dir}`)
+        this.terminal.show();
+        if (reporter) {
+          reporter.sendTelemetryEvent('command', {
+            command: messages.PDKCommandStrings.PdkNewModuleCommandId
+          });
+        }
+      })
+    })
+  }
+
+  public dispose(): any {
+    this.terminal.dispose();
+    this.terminal = undefined;
+  }
+}

--- a/client/src/commands/pdk/pdkTestCommand.ts
+++ b/client/src/commands/pdk/pdkTestCommand.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import ChildProcess = cp.ChildProcess;
+import { Logger } from '../../logging';
+import { reporter } from '../../telemetry/telemetry';
+import * as messages from '../../messages';
+
+export class pdkTestUnitCommand {
+  private logger: Logger = undefined;
+  private terminal: vscode.Terminal = undefined;
+
+  constructor(logger: Logger, terminal: vscode.Terminal) {
+    this.logger = logger;
+    this.terminal = terminal;
+  }
+
+  public run() {
+    this.terminal.sendText(`pdk test unit`);
+    this.terminal.show();
+    if (reporter) {
+      reporter.sendTelemetryEvent('command', {
+        command: messages.PDKCommandStrings.PdkTestUnitCommandId
+      });
+    }
+  }
+
+  public dispose(): any {
+    this.terminal.dispose();
+    this.terminal = undefined;
+  }
+}

--- a/client/src/commands/pdk/pdkValidateCommand.ts
+++ b/client/src/commands/pdk/pdkValidateCommand.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import ChildProcess = cp.ChildProcess;
+import { Logger } from '../../logging';
+import { reporter } from '../../telemetry/telemetry';
+import * as messages from '../../messages';
+
+export class pdkValidateCommand {
+  private logger: Logger = undefined;
+  private terminal: vscode.Terminal = undefined;
+
+  constructor(logger: Logger, terminal: vscode.Terminal) {
+    this.logger = logger;
+    this.terminal = terminal;
+  }
+
+  public run() {
+    this.terminal.sendText(`pdk validate`);
+    this.terminal.show();
+    if (reporter) {
+      reporter.sendTelemetryEvent('command', {
+        command: messages.PDKCommandStrings.PdkValidateCommandId
+      });
+    }
+  }
+
+  public dispose(): any {
+    this.terminal.dispose();
+    this.terminal = undefined;
+  }
+}

--- a/client/src/commands/pdkcommands.ts
+++ b/client/src/commands/pdkcommands.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode';
+import * as messages from '../../src/messages';
+import { IConnectionManager } from '../../src/connection';
+import { Logger } from '../../src/logging';
+import { pdkNewModuleCommand } from './pdk/pdkNewModuleCommand';
+import { pdkNewClassCommand } from './pdk/pdkNewClassCommand';
+import { pdkValidateCommand } from './pdk/pdkValidateCommand';
+import { pdkTestUnitCommand } from './pdk/pdkTestCommand';
+
+export function setupPDKCommands(langID: string, connManager: IConnectionManager, ctx: vscode.ExtensionContext, logger: Logger, terminal: vscode.Terminal) {
+  let newModuleCommand = new pdkNewModuleCommand(logger, terminal);
+  ctx.subscriptions.push(newModuleCommand);
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkNewModuleCommandId, () => {
+    newModuleCommand.run();
+  }));
+
+  let newClassCommand = new pdkNewClassCommand(logger, terminal);
+  ctx.subscriptions.push(newClassCommand);
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkNewClassCommandId, () => {
+    newClassCommand.run();
+  }));
+
+  let validateCommand = new pdkValidateCommand(logger, terminal);
+  ctx.subscriptions.push(validateCommand);
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkValidateCommandId, () => {
+    validateCommand.run();
+  }));
+
+  let testUnitCommand = new pdkTestUnitCommand(logger, terminal);
+  ctx.subscriptions.push(testUnitCommand);
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkTestUnitCommandId, () => {
+    testUnitCommand.run();
+  }));
+}

--- a/client/src/commands/puppet/puppetResourceCommand.ts
+++ b/client/src/commands/puppet/puppetResourceCommand.ts
@@ -1,13 +1,12 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { PuppetResourceRequestParams, PuppetResourceRequest } from '../messages';
-import { IConnectionManager, ConnectionStatus } from '../connection';
-import { Logger } from '../logging';
-import { reporter } from '../telemetry/telemetry';
-import * as messages from '../messages';
+import { IConnectionManager, ConnectionStatus } from '../../connection';
+import { Logger } from '../../logging';
+import { reporter } from '../../telemetry/telemetry';
+import * as messages from '../../messages';
 
-class RequestParams implements PuppetResourceRequestParams {
+class RequestParams implements messages.PuppetResourceRequestParams {
   typename: string;
   title: string;
 }
@@ -49,7 +48,7 @@ export class puppetResourceCommand {
         requestParams.typename = moduleName;
 
         thisCommand._connectionManager.languageClient
-          .sendRequest(PuppetResourceRequest.type, requestParams)
+          .sendRequest(messages.PuppetResourceRequest.type, requestParams)
           .then( (resourceResult) => {
             if (resourceResult.error != undefined && resourceResult.error.length > 0) {
               this.logger.error(resourceResult.error);

--- a/client/src/commands/puppetcommands.ts
+++ b/client/src/commands/puppetcommands.ts
@@ -1,9 +1,12 @@
 import * as vscode from 'vscode';
-import { puppetResourceCommand } from '../src/commands/puppetResourceCommand';
-import * as messages from '../src/messages';
-import { PuppetNodeGraphContentProvider, isNodeGraphFile, getNodeGraphUri, showNodeGraph } from '../src/providers/previewNodeGraphProvider';
-import { IConnectionManager } from './connection';
-import { Logger } from './logging';
+import * as messages from '../../src/messages';
+import { IConnectionManager } from '../../src/connection';
+import { Logger } from '../../src/logging';
+import {
+  PuppetNodeGraphContentProvider, isNodeGraphFile,
+  getNodeGraphUri, showNodeGraph
+} from '../../src/providers/previewNodeGraphProvider';
+import { puppetResourceCommand } from '../commands/puppet/puppetResourceCommand';
 
 export function setupPuppetCommands(langID:string, connManager:IConnectionManager, ctx:vscode.ExtensionContext, logger: Logger){
 

--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -4,7 +4,8 @@ import vscode = require('vscode');
 import cp = require('child_process');
 import { Logger } from '../src/logging';
 import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient';
-import { setupPuppetCommands } from '../src/puppetcommands';
+import { setupPuppetCommands } from '../src/commands/puppetcommands';
+import { setupPDKCommands } from '../src/commands/pdkcommands';
 import * as messages from '../src/messages';
 import fs = require('fs');
 
@@ -48,6 +49,7 @@ export class ConnectionManager implements IConnectionManager {
   private extensionContext = undefined;
   private commandsRegistered = false;
   private logger: Logger = undefined;
+  private terminal: vscode.Terminal = undefined
 
   public get status() : ConnectionStatus {
     return this.connectionStatus;
@@ -71,6 +73,15 @@ export class ConnectionManager implements IConnectionManager {
       this.logger.debug('Configuring commands');
 
       setupPuppetCommands(langID, this, this.extensionContext, this.logger);
+
+      this.terminal = vscode.window.createTerminal('Puppet PDK');
+      this.terminal.processId.then(
+        pid => {
+          console.log("pdk shell started, pid: " + pid);
+        });
+      setupPDKCommands(langID, this, this.extensionContext, this.logger, this.terminal);
+      this.extensionContext.subscriptions.push(this.terminal);
+
       this.commandsRegistered = true;
     }
 

--- a/client/src/messages.ts
+++ b/client/src/messages.ts
@@ -38,3 +38,10 @@ export class PuppetCommandStrings{
   static PuppetResourceCommandId:string = 'extension.puppetResource';
   static PuppetNodeGraphToTheSideCommandId = 'extension.puppetShowNodeGraphToSide';
 }
+
+export class PDKCommandStrings {
+  static PdkNewModuleCommandId: string = 'extension.pdkNewModule';
+  static PdkNewClassCommandId: string = 'extension.pdkNewClass';
+  static PdkValidateCommandId: string = 'extension.pdkValidate';
+  static PdkTestUnitCommandId: string = 'extension.pdkTestUnit';
+}


### PR DESCRIPTION
This adds basic support for the new PDK from Puppet

~~- [ ]  Detect platform and switch path to PDK for new module~~
- [x]  Use existing shell for pdk commands
- [x]  Add telemetry for pdk commands