### PR TITLE
Improved command titles

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -6,11 +6,13 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## Unreleased
 
-## 0.6.1
-
+* Added support for the PDK(https://puppet.com/blog/develop-modules-faster-new-puppet-development-kit)
 * Added telemetry to understand which parts Puppet users find useful. This will help us refine which commands we add in the future. We track whether the following commands are executed:
-  * `foo`
-  * `bar`
+  * `puppet resource`
+  * `pdk new module`
+  * `pdk new class`
+  * `pdk validate`
+  * `pdk test unit`
 
 > Please` note, you can turn off telemetry reporting for VS Code and all extensions through the ["telemetry.enableTelemetry": false setting](https://code.visualstudio.com/docs/supporting/faq#_how-to-disable-telemetry-reporting).
 

--- a/client/README.md
+++ b/client/README.md
@@ -38,6 +38,7 @@ Open any Puppet manifest with the extension '.pp' or 'epp' and the extension wil
 - Validation of `metadata.json` files
 - Import from `puppet resource` directly into manifests
 - Node graph preview
+- Puppet Development Kit integration
 
 ## Feature information
 
@@ -76,6 +77,21 @@ You can preview the [node graph](https://puppet.com/blog/visualize-your-infrastr
 2. Type `puppet open node`.. and press enter
 
 The node graph will appear next to the manifest
+
+### Puppet Development Kit
+
+You can use the [Puppet Development Kit](https://puppet.com/blog/develop-modules-faster-new-puppet-development-kit) inside VS Code from the command palette.
+
+** Note: The PDK must be installed prior to using these commands
+
+The following commands are supported:
+
+- pdk new module
+- pdk new class
+- pdk validate
+- pdk test unit
+
+To use any of the above commands, open the command palette and start typing a command.
 
 ## Installing the Extension
 
@@ -117,3 +133,4 @@ This extension collects telemetry data to help us build a better experience for 
 ## License
 
 This extension is [licensed under the Apache-2.0 License](LICENSE.txt).
+

--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,11 @@
         "onCommand:extension.puppetLint",
         "onCommand:extension.puppetParserValidate",
         "onCommand:extension.puppetShowNodeGraphToSide",
-        "onCommand:extension.puppetResource"
+        "onCommand:extension.puppetResource",
+        "onCommand:extension.pdkNewModule",
+        "onCommand:extension.pdkNewClass",
+        "onCommand:extension.pdkTestUnit",
+        "onCommand:extension.pdkValidate"
     ],
     "main": "./out/src/extension",
     "contributes": {
@@ -83,6 +87,26 @@
             }
         ],
         "commands": [
+            {
+                "command": "extension.pdkTestUnit",
+                "category": "Puppet",
+                "title": "PDK Test Unit"
+            },
+            {
+                "command": "extension.pdkValidate",
+                "category": "Puppet",
+                "title": "PDK Validate"
+            },
+            {
+                "command": "extension.pdkNewModule",
+                "category": "Puppet",
+                "title": "PDK New Module"
+            },
+            {
+                "command": "extension.pdkNewClass",
+                "category": "Puppet",
+                "title": "PDK New Class"
+            },
             {
                 "command": "extension.puppetResource",
                 "category": "Puppet",

--- a/client/package.json
+++ b/client/package.json
@@ -90,32 +90,32 @@
             {
                 "command": "extension.pdkTestUnit",
                 "category": "Puppet",
-                "title": "PDK Test Unit"
+                "title": "pdk test unit: run a Puppet module's unit tests"
             },
             {
                 "command": "extension.pdkValidate",
                 "category": "Puppet",
-                "title": "PDK Validate"
+                "title": "pdk validate: validate syntax and style of a Puppet module"
             },
             {
                 "command": "extension.pdkNewModule",
                 "category": "Puppet",
-                "title": "PDK New Module"
+                "title": "pdk new module: create a new Puppet module"
             },
             {
                 "command": "extension.pdkNewClass",
                 "category": "Puppet",
-                "title": "PDK New Class"
+                "title": "pdk new class: add a new class to an existing Puppet module"
             },
             {
                 "command": "extension.puppetResource",
                 "category": "Puppet",
-                "title": "Puppet Resource",
+                "title": "puppet resource: explore the state of resources and types that Puppet can manage",
                 "when": "editorTextFocus && editorLangId == 'puppet'"
             },
             {
                 "command": "extension.puppetShowNodeGraphToSide",
-                "title": "Open Node Graph to the Side",
+                "title": "Open Puppet Node Graph to the side",
                 "category": "Puppet",
                 "icon": {
                     "light": "./media/PreviewOnRightPane_16x.svg",

--- a/client/src/commands/pdk/pdkNewClassCommand.ts
+++ b/client/src/commands/pdk/pdkNewClassCommand.ts
@@ -1,0 +1,40 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import ChildProcess = cp.ChildProcess;
+import { Logger } from '../../logging';
+import { reporter } from '../../telemetry/telemetry';
+import * as messages from '../../messages';
+
+export class pdkNewClassCommand {
+  private logger: Logger = undefined;
+  private terminal: vscode.Terminal = undefined;
+
+  constructor(logger: Logger, terminal: vscode.Terminal) {
+    this.logger = logger;
+    this.terminal = terminal;
+  }
+
+  public run() {
+    let nameOpts: vscode.QuickPickOptions = {
+      placeHolder: "Enter a name for the new Puppet class",
+      matchOnDescription: true,
+      matchOnDetail: true
+    };
+    vscode.window.showInputBox(nameOpts).then(moduleName => {
+      this.terminal.sendText(`pdk new class ${moduleName}`);
+      this.terminal.show();
+      if (reporter) {
+        reporter.sendTelemetryEvent('command', {
+          command: messages.PDKCommandStrings.PdkNewClassCommandId
+        });
+      }
+    })
+  }
+
+  public dispose(): any {
+    this.terminal.dispose();
+    this.terminal = undefined;
+  }
+}

--- a/client/src/commands/pdk/pdkNewModuleCommand.ts
+++ b/client/src/commands/pdk/pdkNewModuleCommand.ts
@@ -1,0 +1,46 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import { Logger } from '../../logging';
+import { reporter } from '../../telemetry/telemetry';
+import * as messages from '../../messages';
+
+export class pdkNewModuleCommand {
+  private logger: Logger = undefined;
+  private terminal: vscode.Terminal = undefined;
+
+  constructor(logger: Logger, terminal: vscode.Terminal) {
+    this.logger = logger;
+    this.terminal = terminal;
+  }
+
+  public run() {
+    let nameOpts: vscode.QuickPickOptions = {
+      placeHolder: "Enter a name for the new Puppet module",
+      matchOnDescription: true,
+      matchOnDetail: true
+    };
+    let dirOpts: vscode.QuickPickOptions = {
+      placeHolder: "Enter a path for the new Puppet module",
+      matchOnDescription: true,
+      matchOnDetail: true
+    };
+
+    vscode.window.showInputBox(nameOpts).then(moduleName => {
+      vscode.window.showInputBox(dirOpts).then(dir => {
+        this.terminal.sendText(`pdk new module --skip-interview ${moduleName} ${dir} && code ${dir} `);
+        this.terminal.show();
+        if (reporter) {
+          reporter.sendTelemetryEvent('command', {
+            command: messages.PDKCommandStrings.PdkNewModuleCommandId
+          });
+        }
+      })
+    })
+  }
+
+  public dispose(): any {
+    this.terminal.dispose();
+    this.terminal = undefined;
+  }
+}

--- a/client/src/commands/pdk/pdkTestCommand.ts
+++ b/client/src/commands/pdk/pdkTestCommand.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import ChildProcess = cp.ChildProcess;
+import { Logger } from '../../logging';
+import { reporter } from '../../telemetry/telemetry';
+import * as messages from '../../messages';
+
+export class pdkTestUnitCommand {
+  private logger: Logger = undefined;
+  private terminal: vscode.Terminal = undefined;
+
+  constructor(logger: Logger, terminal: vscode.Terminal) {
+    this.logger = logger;
+    this.terminal = terminal;
+  }
+
+  public run() {
+    this.terminal.sendText(`pdk test unit`);
+    this.terminal.show();
+    if (reporter) {
+      reporter.sendTelemetryEvent('command', {
+        command: messages.PDKCommandStrings.PdkTestUnitCommandId
+      });
+    }
+  }
+
+  public dispose(): any {
+    this.terminal.dispose();
+    this.terminal = undefined;
+  }
+}

--- a/client/src/commands/pdk/pdkValidateCommand.ts
+++ b/client/src/commands/pdk/pdkValidateCommand.ts
@@ -1,0 +1,33 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+import ChildProcess = cp.ChildProcess;
+import { Logger } from '../../logging';
+import { reporter } from '../../telemetry/telemetry';
+import * as messages from '../../messages';
+
+export class pdkValidateCommand {
+  private logger: Logger = undefined;
+  private terminal: vscode.Terminal = undefined;
+
+  constructor(logger: Logger, terminal: vscode.Terminal) {
+    this.logger = logger;
+    this.terminal = terminal;
+  }
+
+  public run() {
+    this.terminal.sendText(`pdk validate`);
+    this.terminal.show();
+    if (reporter) {
+      reporter.sendTelemetryEvent('command', {
+        command: messages.PDKCommandStrings.PdkValidateCommandId
+      });
+    }
+  }
+
+  public dispose(): any {
+    this.terminal.dispose();
+    this.terminal = undefined;
+  }
+}

--- a/client/src/commands/pdkcommands.ts
+++ b/client/src/commands/pdkcommands.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode';
+import * as messages from '../../src/messages';
+import { IConnectionManager } from '../../src/connection';
+import { Logger } from '../../src/logging';
+import { pdkNewModuleCommand } from './pdk/pdkNewModuleCommand';
+import { pdkNewClassCommand } from './pdk/pdkNewClassCommand';
+import { pdkValidateCommand } from './pdk/pdkValidateCommand';
+import { pdkTestUnitCommand } from './pdk/pdkTestCommand';
+
+export function setupPDKCommands(langID: string, connManager: IConnectionManager, ctx: vscode.ExtensionContext, logger: Logger, terminal: vscode.Terminal) {
+  let newModuleCommand = new pdkNewModuleCommand(logger, terminal);
+  ctx.subscriptions.push(newModuleCommand);
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkNewModuleCommandId, () => {
+    newModuleCommand.run();
+  }));
+
+  let newClassCommand = new pdkNewClassCommand(logger, terminal);
+  ctx.subscriptions.push(newClassCommand);
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkNewClassCommandId, () => {
+    newClassCommand.run();
+  }));
+
+  let validateCommand = new pdkValidateCommand(logger, terminal);
+  ctx.subscriptions.push(validateCommand);
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkValidateCommandId, () => {
+    validateCommand.run();
+  }));
+
+  let testUnitCommand = new pdkTestUnitCommand(logger, terminal);
+  ctx.subscriptions.push(testUnitCommand);
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PDKCommandStrings.PdkTestUnitCommandId, () => {
+    testUnitCommand.run();
+  }));
+}

--- a/client/src/commands/puppet/puppetResourceCommand.ts
+++ b/client/src/commands/puppet/puppetResourceCommand.ts
@@ -1,13 +1,12 @@
 'use strict';
 
 import * as vscode from 'vscode';
-import { PuppetResourceRequestParams, PuppetResourceRequest } from '../messages';
-import { IConnectionManager, ConnectionStatus } from '../connection';
-import { Logger } from '../logging';
-import { reporter } from '../telemetry/telemetry';
-import * as messages from '../messages';
+import { IConnectionManager, ConnectionStatus } from '../../connection';
+import { Logger } from '../../logging';
+import { reporter } from '../../telemetry/telemetry';
+import * as messages from '../../messages';
 
-class RequestParams implements PuppetResourceRequestParams {
+class RequestParams implements messages.PuppetResourceRequestParams {
   typename: string;
   title: string;
 }
@@ -49,7 +48,7 @@ export class puppetResourceCommand {
         requestParams.typename = moduleName;
 
         thisCommand._connectionManager.languageClient
-          .sendRequest(PuppetResourceRequest.type, requestParams)
+          .sendRequest(messages.PuppetResourceRequest.type, requestParams)
           .then( (resourceResult) => {
             if (resourceResult.error != undefined && resourceResult.error.length > 0) {
               this.logger.error(resourceResult.error);

--- a/client/src/commands/puppetcommands.ts
+++ b/client/src/commands/puppetcommands.ts
@@ -1,9 +1,12 @@
 import * as vscode from 'vscode';
-import { puppetResourceCommand } from '../src/commands/puppetResourceCommand';
-import * as messages from '../src/messages';
-import { PuppetNodeGraphContentProvider, isNodeGraphFile, getNodeGraphUri, showNodeGraph } from '../src/providers/previewNodeGraphProvider';
-import { IConnectionManager } from './connection';
-import { Logger } from './logging';
+import * as messages from '../../src/messages';
+import { IConnectionManager } from '../../src/connection';
+import { Logger } from '../../src/logging';
+import {
+  PuppetNodeGraphContentProvider, isNodeGraphFile,
+  getNodeGraphUri, showNodeGraph
+} from '../../src/providers/previewNodeGraphProvider';
+import { puppetResourceCommand } from '../commands/puppet/puppetResourceCommand';
 
 export function setupPuppetCommands(langID:string, connManager:IConnectionManager, ctx:vscode.ExtensionContext, logger: Logger){
 

--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -4,7 +4,8 @@ import vscode = require('vscode');
 import cp = require('child_process');
 import { Logger } from '../src/logging';
 import { LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient';
-import { setupPuppetCommands } from '../src/puppetcommands';
+import { setupPuppetCommands } from '../src/commands/puppetcommands';
+import { setupPDKCommands } from '../src/commands/pdkcommands';
 import * as messages from '../src/messages';
 import fs = require('fs');
 
@@ -47,6 +48,7 @@ export class ConnectionManager implements IConnectionManager {
   private extensionContext = undefined;
   private commandsRegistered = false;
   private logger: Logger = undefined;
+  private terminal: vscode.Terminal = undefined
 
   public get status() : ConnectionStatus {
     return this.connectionStatus;
@@ -69,7 +71,16 @@ export class ConnectionManager implements IConnectionManager {
     if (!this.commandsRegistered) {
       this.logger.debug('Configuring commands');
 
+      this.terminal = vscode.window.createTerminal('Puppet PDK');
+      this.terminal.show();
+      this.terminal.processId.then(
+        pid => {
+          console.log("pdk shell started, pid: " + pid);
+        });
+
       setupPuppetCommands(langID, this, this.extensionContext, this.logger);
+      setupPDKCommands(langID, this, this.extensionContext, this.logger, this.terminal);
+      this.extensionContext.subscriptions.push(this.terminal);
       this.commandsRegistered = true;
     }
 

--- a/client/src/messages.ts
+++ b/client/src/messages.ts
@@ -38,3 +38,10 @@ export class PuppetCommandStrings{
   static PuppetResourceCommandId:string = 'extension.puppetResource';
   static PuppetNodeGraphToTheSideCommandId = 'extension.puppetShowNodeGraphToSide';
 }
+
+export class PDKCommandStrings {
+  static PdkNewModuleCommandId: string = 'extension.pdkNewModule';
+  static PdkNewClassCommandId: string = 'extension.pdkNewClass';
+  static PdkValidateCommandId: string = 'extension.pdkValidate';
+  static PdkTestUnitCommandId: string = 'extension.pdkTestUnit';
+}


### PR DESCRIPTION
Improving clarity of command titles:
- Explicitly show CLI commands, e.g. pdk new class, plus a description of what it does
- Have "Puppet" in all titles so that typing Puppet shows all available commands

Note: I don't know if using this style is conventional for VS Code or plugins. Feedback on that desired.