### PR TITLE
(GH-120) Configurable Puppet Agent directory

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -166,6 +166,11 @@
                     "type": "string",
                     "default": "normal",
                     "description": "Set the minimum log level that the user will see on the Puppet OutputChannel (Allowed values: verbose, debug, normal, warning, error)"
+                },
+                "puppet.puppetAgentDir": {
+                  "type": "string",
+                  "default": "normal",
+                  "description": "The fully qualified path to the Puppet agent install directory. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'"
                 }
             }
         }

--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -31,6 +31,7 @@ export interface IConnectionConfiguration {
   timeout: number;
   preLoadPuppet: boolean;
   debugFilePath: string;
+  puppetAgentDir: string;
 }
 
 export interface IConnectionManager {
@@ -214,7 +215,12 @@ export class ConnectionManager implements IConnectionManager {
           comspec = path.join(process.env["WINDIR"],"sysnative","cmd.exe");
           programFiles = process.env["ProgramW6432"];
         }
-        let puppetDir : string = path.join(programFiles,"Puppet Labs","Puppet")
+        let puppetDir: string = undefined;
+        if (this.connectionConfiguration.puppetAgentDir == undefined) {
+          puppetDir = path.join(programFiles, "Puppet Labs", "Puppet");
+        } else {
+          puppetDir = this.connectionConfiguration.puppetAgentDir;
+        }
         let environmentBat : string = path.join(puppetDir,"bin","environment.bat")
 
         if (!fs.existsSync(puppetDir)) {
@@ -233,8 +239,12 @@ export class ConnectionManager implements IConnectionManager {
       default:
         this.logger.debug('Starting language server')
 
-        // Try and find the puppet-agent ruby
-        let rubyPath : string = '/opt/puppetlabs/puppet/bin/ruby';
+        let rubyPath: string = undefined;
+        if (this.connectionConfiguration.puppetAgentDir == undefined) {
+          rubyPath = '/opt/puppetlabs/puppet/bin/ruby';
+        } else {
+          rubyPath = path.join(this.connectionConfiguration.puppetAgentDir, "bin", "ruby");
+        }
         if (fs.existsSync(rubyPath)) { cmd = rubyPath }
 
         // Default to ruby on the path

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -20,6 +20,7 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
   public timeout: number = undefined;
   public preLoadPuppet: boolean = undefined;
   public debugFilePath: string = undefined;
+  public puppetAgentDir: string = undefined;
 
   constructor(context: vscode.ExtensionContext) {
     let config = vscode.workspace.getConfiguration('puppet');
@@ -29,6 +30,8 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
     this.timeout       = config['languageserver']['timeout'];
     this.preLoadPuppet = config['languageserver']['preLoadPuppet'];
     this.debugFilePath = config['languageserver']['debugFilePath'];
+    
+    this.puppetAgentDir = config['puppetAgentDir'];
   }
 }
 


### PR DESCRIPTION
This adds a configuration point to choose a custom path to the
Puppet agent. This allows non default installation paths for all
supported OS.