### PR TITLE
Fix completion provider with Puppet 5.2.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,10 @@ environment:
   - PUPPET_GEM_VERSION: "~> 5.0"
     RUBY_VER: 24-x64
     RAKE_TASK: test
+  # Specific Puppet version testing
+  - PUPPET_GEM_VERSION: "5.1.0"
+    RUBY_VER: 24-x64
+    RAKE_TASK: test
 
   # Ruby style
   - PUPPET_GEM_VERSION: "~> 4.0"

--- a/server/lib/puppet-languageserver/completion_provider.rb
+++ b/server/lib/puppet-languageserver/completion_provider.rb
@@ -4,7 +4,7 @@ module PuppetLanguageServer
       items = []
       incomplete = false
 
-      result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num, true, [Puppet::Pops::Model::QualifiedName])
+      result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num, true, [Puppet::Pops::Model::QualifiedName, Puppet::Pops::Model::BlockExpression])
 
       if result.nil?
         # We are in the root of the document.

--- a/server/lib/puppet-languageserver/hover_provider.rb
+++ b/server/lib/puppet-languageserver/hover_provider.rb
@@ -1,7 +1,7 @@
 module PuppetLanguageServer
   module HoverProvider
     def self.resolve(content, line_num, char_num)
-      result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num, false, [Puppet::Pops::Model::QualifiedName])
+      result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num, false, [Puppet::Pops::Model::QualifiedName, Puppet::Pops::Model::BlockExpression])
       return LanguageServer::Hover.create_nil_response if result.nil?
 
       path = result[:path]


### PR DESCRIPTION
Puppet issue 7668 (https://tickets.puppetlabs.com/browse/PUP-7668) was fixed in
the puppet gem 5.2.0, which then caused parsing to work correctly.  However this
meant that root document checks were returning a BlockExpression object instead
of nil.  This commit changes the parsing so that the BlockExpression class as it
is a container for other objects and can not be auto-completed in of itself.

This commit also adds testing of Puppet gem 5.1.0 as this version of Puppet does
not contain the PUP-7668 fix and we must ensure that all puppet versions have
the same autocomplete behaviour.