### PR TITLE
(GH-120) Fix default PuppetAgentDir on Windows

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -259,7 +259,7 @@
         },
         "puppet.puppetAgentDir": {
           "type": "string",
-          "default": "normal",
+          "default": null,
           "description": "The fully qualified path to the Puppet agent install directory. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'"
         }
       }


### PR DESCRIPTION
Previously the PuppetAgentDir default value was set to 'normal' which appears
to be a copy-paste error.  This causes the extension to try and load the
puppet language server at 'normal' in the file system which then promptly fails
on Windows.  This commit changes the default to null in JSON which then
appears in the TypeScript as undefined, and restores the previous behaviour.