### PR TITLE
(GH-130) Prepare to use PDK ruby if puppet agent not available

### DIFF
--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -209,12 +209,31 @@ export class ConnectionManager implements IConnectionManager {
     callback(proc);
   }
 
-  private createLanguageServerProcess(serverExe: string, callback : Function) {
-    this.logger.debug('Language server found at: ' + serverExe)
+  private getDirectories(parent) {
+    return fs.readdirSync(parent).filter(function (file) {
+      return fs.statSync(path.join(parent, file)).isDirectory();
+    });
+  }
 
-    let cmd: string = undefined;
-    let args = [serverExe];
-    let options : cp.SpawnOptions = {};
+  private pathEnvSeparator() {
+    if (process.platform == 'win32') {
+      return ";";
+    } else {
+      return ":";
+    }
+  }
+
+  private getLanguageServerFromPuppetAgent(serverExe) {
+    let logPrefix: string = '[getLanguageServerFromPuppetAgent] ';
+    // setup defaults
+    let spawn_options: cp.SpawnOptions = {}
+    spawn_options.env = process.env;
+    let result = {
+      command: 'ruby',
+      args: [serverExe],
+      options: spawn_options,
+    }
+    let puppetAgentDir: string = null;
 
     // type Platform = 'aix'
     //               | 'android'
@@ -234,61 +253,182 @@ export class ConnectionManager implements IConnectionManager {
           comspec = path.join(process.env["WINDIR"],"sysnative","cmd.exe");
           programFiles = process.env["ProgramW6432"];
         }
-        let puppetDir: string = undefined;
+
         if (this.connectionConfiguration.puppetAgentDir == undefined) {
-          puppetDir = path.join(programFiles, "Puppet Labs", "Puppet");
+          puppetAgentDir = path.join(programFiles, "Puppet Labs", "Puppet");
         } else {
-          puppetDir = this.connectionConfiguration.puppetAgentDir;
-        }
-        let environmentBat : string = path.join(puppetDir,"bin","environment.bat")
-
-        if (!fs.existsSync(puppetDir)) {
-          this.setSessionFailure("Could not find Puppet Agent at " + puppetDir);
-          vscode.window.showWarningMessage('Could not find Puppet Agent installed at "' + puppetDir + '". Functionality will be limited to syntax highlighting');
-          return;
+          puppetAgentDir = this.connectionConfiguration.puppetAgentDir;
         }
 
-        cmd = comspec;
-        args = ['/K','CALL',environmentBat,'&&','ruby.exe',serverExe]
-        options = {
-          env: process.env,
-          stdio: 'pipe',
-        };
+        result.options.stdio = 'pipe';
         break;
       default:
-        this.logger.debug('Starting language server')
-
-        let rubyPath: string = undefined;
         if (this.connectionConfiguration.puppetAgentDir == undefined) {
-          rubyPath = '/opt/puppetlabs/puppet/bin/ruby';
+          puppetAgentDir = '/opt/puppetlabs/puppet';
         } else {
-          rubyPath = path.join(this.connectionConfiguration.puppetAgentDir, "bin", "ruby");
+          puppetAgentDir = this.connectionConfiguration.puppetAgentDir;
         }
-        if (fs.existsSync(rubyPath)) { cmd = rubyPath }
 
-        // Default to ruby on the path
-        if (cmd == undefined) { cmd = 'ruby' }
-        options = {
-          shell: true,
-          env: process.env,
-          stdio: 'pipe',
-        };
+        result.options.stdio = 'pipe';
+        result.options.shell = true;
+        break;
+    }
+    // Check if this really is a Puppet Agent installation
+    if (!fs.existsSync(path.join(puppetAgentDir, "VERSION"))) {
+      this.logger.debug(logPrefix + "Could not find a valid Puppet Agent installation at " + puppetAgentDir);
+      return null;
+    } else {
+      this.logger.debug(logPrefix + "Found a valid Puppet Agent installation at " + puppetAgentDir);
     }
 
-    if (cmd == undefined) {
-      this.setSessionFailure("Unable to start the Language Server on this platform");
-      vscode.window.showWarningMessage('The Puppet Language Server is not supported on this platform (' + process.platform + '). Functionality will be limited to syntax highlighting');
+    let puppetDir = path.join(puppetAgentDir,"puppet");
+    let facterDir = path.join(puppetAgentDir,"facter");
+    let hieraDir = path.join(puppetAgentDir,"hiera");
+    let mcoDir = path.join(puppetAgentDir,"mcollective");
+    let rubydir = path.join(puppetAgentDir,"sys","ruby");
+    let rubylib = path.join(puppetDir,"lib") + this.pathEnvSeparator() + path.join(facterDir,"lib") + this.pathEnvSeparator() + path.join(hieraDir,"lib") + this.pathEnvSeparator() + path.join(mcoDir,"lib")
+
+    if (process.platform == 'win32') {
+      // Translate all slashes to / style to avoid puppet/ruby issue #11930
+      rubylib = rubylib.replace(/\\/g,"/");
+    }
+
+    // Setup the process environment variables
+    if (result.options.env.PATH == undefined) { result.options.env.PATH = ''; }
+    if (result.options.env.RUBYLIB == undefined) { result.options.env.RUBYLIB = ''; }
+    result.options.env.RUBY_DIR = rubydir;
+    result.options.env.PATH = path.join(puppetDir,"bin") + this.pathEnvSeparator() + path.join(facterDir,"bin") + this.pathEnvSeparator() + path.join(hieraDir,"bin") + this.pathEnvSeparator() + path.join(mcoDir,"bin") +
+                              this.pathEnvSeparator() + path.join(puppetAgentDir,"bin") + this.pathEnvSeparator() + path.join(rubydir,"bin") + this.pathEnvSeparator() + path.join(puppetAgentDir,"sys","tools","bin") +
+                              this.pathEnvSeparator() + result.options.env.PATH;
+    result.options.env.RUBYLIB = rubylib + this.pathEnvSeparator() + result.options.env.RUBYLIB;
+    result.options.env.RUBYOPT = 'rubygems';
+    result.options.env.SSL_CERT_FILE = path.join(puppetDir,"ssl","cert.pem");
+    result.options.env.SSL_CERT_DIR = path.join(puppetDir,"ssl","certs");
+
+    this.logger.debug(logPrefix + "Using environment variable RUBY_DIR=" + result.options.env.RUBY_DIR);
+    this.logger.debug(logPrefix + "Using environment variable PATH=" + result.options.env.PATH);
+    this.logger.debug(logPrefix + "Using environment variable RUBYLIB=" + result.options.env.RUBYLIB);
+    this.logger.debug(logPrefix + "Using environment variable RUBYOPT=" + result.options.env.RUBYOPT);
+    this.logger.debug(logPrefix + "Using environment variable SSL_CERT_FILE=" + result.options.env.SSL_CERT_FILE);
+    this.logger.debug(logPrefix + "Using environment variable SSL_CERT_DIR=" + result.options.env.SSL_CERT_DIR);
+
+    return result;
+  }
+
+  // Commented out for the moment.  This will be enabled once the configuration and 
+  // exact user story is figured out.
+  //
+  // private getLanguageServerFromPDK(serverExe) {
+  //   let logPrefix: string = '[getLanguageServerFromPDK] ';
+  //   // setup defaults
+  //   let spawn_options: cp.SpawnOptions = {}
+  //   spawn_options.env = process.env;
+  //   let result = {
+  //     command: 'ruby',
+  //     args: [serverExe],
+  //     options: spawn_options,
+  //   }
+  //   let pdkDir: string = null;
+
+  //   // type Platform = 'aix'
+  //   //               | 'android'
+  //   //               | 'darwin'
+  //   //               | 'freebsd'
+  //   //               | 'linux'
+  //   //               | 'openbsd'
+  //   //               | 'sunos'
+  //   //               | 'win32';
+  //   switch (process.platform) {
+  //     case 'win32':
+  //       let comspec: string = process.env["COMSPEC"];
+  //       let programFiles = process.env["ProgramFiles"];
+  //       if (process.env["PROCESSOR_ARCHITEW6432"] == "AMD64") {
+  //         // VSCode is running as 32bit process on a 64bit Operating System.  Need to break out
+  //         // of the 32bit using the sysnative redirection and environment variables
+  //         comspec = path.join(process.env["WINDIR"],"sysnative","cmd.exe");
+  //         programFiles = process.env["ProgramW6432"];
+  //       }
+
+  //       pdkDir = path.join(programFiles, "Puppet Labs", "DevelopmentKit");
+
+  //       result.options.stdio = 'pipe';
+  //       break;
+  //     default:
+  //       pdkDir = '/opt/puppetlabs/pdk';
+
+  //       result.options.stdio = 'pipe';
+  //       result.options.shell = true;
+  //       break;
+  //   }
+  //   // Check if this really is a PDK installation
+  //   if (!fs.existsSync(path.join(pdkDir, "PDK_VERSION"))) {
+  //     this.logger.debug(logPrefix + "Could not find a valid PDK installation at " + pdkDir);
+  //     return null;
+  //   } else {
+  //     this.logger.debug(logPrefix + "Found a valid PDK installation at " + pdkDir);
+  //   }
+      
+  //   // Now to detect ruby versions
+  //   let subdirs = this.getDirectories(path.join(pdkDir,"private", "ruby"));
+  //   if (subdirs.length == 0) { return null; }
+  //   let rubyDir = path.join(pdkDir,"private", "ruby",subdirs[0]);
+
+  //   subdirs = this.getDirectories(path.join(pdkDir,"share","cache","ruby"));
+  //   if (subdirs.length == 0) { return null; }
+  //   let gemDir = path.join(pdkDir,"share","cache","ruby",subdirs[0]);
+
+  //   let rubylib = path.join(pdkDir,'lib')
+  //   if (process.platform == 'win32') {
+  //     // Translate all slashes to / style to avoid puppet/ruby issue #11930
+  //     rubylib = rubylib.replace(/\\/g,"/");
+  //     gemDir = gemDir.replace(/\\/g,"/");
+  //   }
+
+  //   // Setup the process environment variables
+  //   if (result.options.env.PATH == undefined) { result.options.env.PATH = '' }
+  //   if (result.options.env.RUBYLIB == undefined) { result.options.env.RUBYLIB = '' }
+    
+  //   result.options.env.RUBY_DIR = rubyDir;
+  //   result.options.env.PATH = path.join(pdkDir,'bin') + this.pathEnvSeparator() + path.join(rubyDir,'bin') + this.pathEnvSeparator() + result.options.env.PATH;
+  //   result.options.env.RUBYLIB = path.join(pdkDir,'lib') + this.pathEnvSeparator() + result.options.env.RUBYLIB;
+  //   result.options.env.GEM_PATH = gemDir;
+  //   result.options.env.GEM_HOME = gemDir;
+  //   result.options.env.RUBYOPT = 'rubygems';
+
+  //   this.logger.debug(logPrefix + "Using environment variable RUBY_DIR=" + result.options.env.RUBY_DIR);
+  //   this.logger.debug(logPrefix + "Using environment variable PATH=" + result.options.env.PATH);
+  //   this.logger.debug(logPrefix + "Using environment variable RUBYLIB=" + result.options.env.RUBYLIB);
+  //   this.logger.debug(logPrefix + "Using environment variable GEM_PATH=" + result.options.env.GEM_PATH);
+  //   this.logger.debug(logPrefix + "Using environment variable GEM_HOME=" + result.options.env.GEM_HOME);
+  //   this.logger.debug(logPrefix + "Using environment variable RUBYOPT=" + result.options.env.RUBYOPT);
+    
+  //   return result;
+  // }
+
+  private createLanguageServerProcess(serverExe: string, callback : Function) {
+    let logPrefix: string = '[createLanguageServerProcess] ';
+    this.logger.debug(logPrefix + 'Language server found at: ' + serverExe)
+
+    let localServer = null
+
+    if (localServer == null) { localServer = this.getLanguageServerFromPuppetAgent(serverExe); }
+    // if (localServer == null) { localServer = this.getLanguageServerFromPDK(serverExe); }
+
+    if (localServer == null) {
+      this.logger.warning(logPrefix + "Could not find a valid Puppet Agent installation");
+      this.setSessionFailure("Could not find a valid Puppet Agent installation");
+      vscode.window.showWarningMessage('Could not find a valid Puppet Agent installation. Functionality will be limited to syntax highlighting');
       return;
     }
 
     let connMgr : ConnectionManager = this;
     let logger = this.logger;
     // Start a server to get a random port
-    this.logger.debug('Creating server process to identify random port')
+    this.logger.debug(logPrefix + 'Creating server process to identify random port')
     const server = net.createServer()
       .on('close', () => {
-        logger.debug('Server process to identify random port disconnected');
-        connMgr.startLanguageServerProcess(cmd, args, options, callback);
+        logger.debug(logPrefix + 'Server process to identify random port disconnected');
+        connMgr.startLanguageServerProcess(localServer.command, localServer.args, localServer.options, callback);
       })
       .on('error', (err) => {
         throw err;
@@ -296,7 +436,7 @@ export class ConnectionManager implements IConnectionManager {
 
     // Listen on random port
     server.listen(0);
-    this.logger.debug('Selected port for local language server: ' + server.address().port);
+    this.logger.debug(logPrefix + 'Selected port for local language server: ' + server.address().port);
     connMgr.connectionConfiguration.port = server.address().port;
     server.close();
   }


### PR DESCRIPTION
Previously the language server required a puppet-agent installation however
some users are not able to install a puppet-agent, but instead the PDK.  This
commit changes the connect.ts script;

- Refactors the ruby detection into two helpers, getLanguageServerFromPDK and
  getLanguageServerFromPuppetAgent.  These helpers are responsible for detecting
  and setting up the process creation for their respective ruby environments on
  any platform type
- Removes the need for environment.bat on Windows by setting up the process env
  variables at process creation
- Updates the logging to be more verbose in the detection methods

Note the functionality to actually use the PDK is currently disabled as the
configuration settings and user story need to be completed first.  However to
not lose the effort, the code still exists but is commented out.