### PR TITLE
(GH-136)(GH-61) Make client langserver better

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -38,6 +38,8 @@
   ],
   "activationEvents": [
     "onLanguage:puppet",
+    "onCommand:extension.puppetRestartSession",
+    "onCommand:extension.puppetShowConnectionLogs",
     "onCommand:extension.puppetShowConnectionMenu",
     "onCommand:extension.puppetLint",
     "onCommand:extension.puppetParserValidate",
@@ -139,6 +141,12 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "extension.puppetRestartSession"
+        },
+        {
+          "command": "extension.puppetShowConnectionLogs"
+        },
         {
           "command": "extension.pdkNewModule"
         },

--- a/client/package.json
+++ b/client/package.json
@@ -38,6 +38,7 @@
   ],
   "activationEvents": [
     "onLanguage:puppet",
+    "onCommand:extension.puppetShowConnectionMenu",
     "onCommand:extension.puppetLint",
     "onCommand:extension.puppetParserValidate",
     "onCommand:extension.puppetShowNodeGraphToSide",
@@ -87,6 +88,16 @@
       }
     ],
     "commands": [
+      {
+        "command": "extension.puppetRestartSession",
+        "category": "Puppet",
+        "title": "Restart Current Session"
+      },
+      {
+        "command": "extension.puppetShowConnectionLogs",
+        "category": "Puppet",
+        "title": "Show Connection Logs"
+      },
       {
         "command": "extension.pdkNewModule",
         "category": "Puppet",

--- a/client/package.json
+++ b/client/package.json
@@ -255,7 +255,8 @@
         "puppet.languageclient.minimumUserLogLevel": {
           "type": "string",
           "default": "normal",
-          "description": "Set the minimum log level that the user will see on the Puppet OutputChannel (Allowed values: verbose, debug, normal, warning, error)"
+          "description": "Set the minimum log level that the user will see on the Puppet connection logs",
+          "enum": ["verbose", "debug", "normal", "warning", "error" ]
         },
         "puppet.puppetAgentDir": {
           "type": "string",

--- a/client/src/commands/puppetcommands.ts
+++ b/client/src/commands/puppetcommands.ts
@@ -24,6 +24,14 @@ export function setupPuppetCommands(langID:string, connManager:IConnectionManage
     () => { connManager.showConnectionMenu(); }
   ));
 
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PuppetCommandStrings.PuppetShowConnectionLogsCommandId,
+    () => { connManager.showLogger(); }
+  ));
+
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PuppetCommandStrings.PuppetRestartSessionCommandId,
+    () => { connManager.restartConnection(); }
+  ));
+
   const contentProvider = new PuppetNodeGraphContentProvider(ctx, connManager);
   const contentProviderRegistration = vscode.workspace.registerTextDocumentContentProvider(langID, contentProvider);
 

--- a/client/src/commands/puppetcommands.ts
+++ b/client/src/commands/puppetcommands.ts
@@ -19,7 +19,11 @@ export function setupPuppetCommands(langID:string, connManager:IConnectionManage
   ctx.subscriptions.push(vscode.commands.registerCommand(messages.PuppetCommandStrings.PuppetNodeGraphToTheSideCommandId,
     uri => showNodeGraph(uri, true))
   );
-  
+
+  ctx.subscriptions.push(vscode.commands.registerCommand(messages.PuppetCommandStrings.PuppetShowConnectionMenuCommandId,
+    () => { connManager.showConnectionMenu(); }
+  ));
+
   const contentProvider = new PuppetNodeGraphContentProvider(ctx, connManager);
   const contentProviderRegistration = vscode.workspace.registerTextDocumentContentProvider(langID, contentProvider);
 

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -1,0 +1,27 @@
+'use strict';
+
+import * as vscode from 'vscode';
+
+import { ConnectionManager, IConnectionConfiguration, ConnectionType } from './connection';
+
+export class ConnectionConfiguration implements IConnectionConfiguration {
+  public type: ConnectionType = ConnectionType.Unknown; 
+  public host: string = undefined;
+  public port: number = undefined;
+  public timeout: number = undefined;
+  public preLoadPuppet: boolean = undefined;
+  public debugFilePath: string = undefined;
+  public puppetAgentDir: string = undefined;
+
+  constructor(context: vscode.ExtensionContext) {
+    let config = vscode.workspace.getConfiguration('puppet');
+
+    this.host          = config['languageserver']['address'];
+    this.port          = config['languageserver']['port'];
+    this.timeout       = config['languageserver']['timeout'];
+    this.preLoadPuppet = config['languageserver']['preLoadPuppet'];
+    this.debugFilePath = config['languageserver']['debugFilePath'];
+    
+    this.puppetAgentDir = config['puppetAgentDir'];
+  }
+}

--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -41,6 +41,8 @@ export interface IConnectionManager {
   status: ConnectionStatus;
   languageClient: LanguageClient;
   showConnectionMenu();
+  showLogger();
+  restartConnection(connectionConfig?: IConnectionConfiguration);
 }
 
 export class ConnectionManager implements IConnectionManager {
@@ -59,6 +61,9 @@ export class ConnectionManager implements IConnectionManager {
   }
   public get languageClient() : LanguageClient {
     return this.languageServerClient;
+  }
+  public showLogger() {
+    this.logger.show()
   }
 
   constructor(context: vscode.ExtensionContext, logger: Logger) {
@@ -387,10 +392,12 @@ export class ConnectionManager implements IConnectionManager {
     });
   }
 
-
-  private restartConnection(connectionConfig?: IConnectionConfiguration) {
-      this.stop();
-      this.start(connectionConfig);
+  public restartConnection(connectionConfig?: IConnectionConfiguration) {
+    if (connectionConfig == undefined) {
+      connectionConfig = new ConnectionConfiguration(this.extensionContext);
+    }
+    this.stop();
+    this.start(connectionConfig);
   }
 
   private createStatusBarItem() {
@@ -413,21 +420,16 @@ export class ConnectionManager implements IConnectionManager {
   public showConnectionMenu() {
     var menuItems: ConnectionMenuItem[] = [];
 
-    let currentConnectionConfig = this.connectionConfiguration;
-
     menuItems.push(
       new ConnectionMenuItem(
         "Restart Current Puppet Session",
-        () => {
-          let configuration = new ConnectionConfiguration(this.extensionContext);
-          this.restartConnection(configuration);
-        }),
+        () => { vscode.commands.executeCommand(messages.PuppetCommandStrings.PuppetRestartSessionCommandId); }),
     )
 
     menuItems.push(
       new ConnectionMenuItem(
         "Show Puppet Session Logs",
-        () => { this.logger.show(); }),
+        () => { vscode.commands.executeCommand(messages.PuppetCommandStrings.PuppetShowConnectionLogsCommandId); }),
     )
 
     vscode

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 
 import { ConnectionManager, IConnectionConfiguration, ConnectionType } from './connection';
+import { ConnectionConfiguration } from './configuration';
 import { Logger } from './logging';
 import { Reporter } from './telemetry/telemetry';
 
@@ -12,28 +13,6 @@ var statusBarItem;
 var serverProc;
 
 var connManager: ConnectionManager = undefined;
-
-export class ConnectionConfiguration implements IConnectionConfiguration {
-  public type: ConnectionType = ConnectionType.Unknown; 
-  public host: string = undefined;
-  public port: number = undefined;
-  public timeout: number = undefined;
-  public preLoadPuppet: boolean = undefined;
-  public debugFilePath: string = undefined;
-  public puppetAgentDir: string = undefined;
-
-  constructor(context: vscode.ExtensionContext) {
-    let config = vscode.workspace.getConfiguration('puppet');
-
-    this.host          = config['languageserver']['address'];
-    this.port          = config['languageserver']['port'];
-    this.timeout       = config['languageserver']['timeout'];
-    this.preLoadPuppet = config['languageserver']['preLoadPuppet'];
-    this.debugFilePath = config['languageserver']['debugFilePath'];
-    
-    this.puppetAgentDir = config['puppetAgentDir'];
-  }
-}
 
 export function activate(context: vscode.ExtensionContext) {
   const puppetExtension = vscode.extensions.getExtension('jpogran.puppet-vscode')!;

--- a/client/src/logging.ts
+++ b/client/src/logging.ts
@@ -19,7 +19,6 @@ export class Logger {
 
   constructor() {
     this.logChannel = vscode.window.createOutputChannel("Puppet");
-    this.logChannel.show();
 
     let config = vscode.workspace.getConfiguration('puppet');
     let logLevelName = config['languageclient']['minimumUserLogLevel'];
@@ -31,6 +30,10 @@ export class Logger {
     } else {
       this.minimumUserLogLevel = logLevel;
     }
+  }
+
+  public show(){
+    this.logChannel.show();
   }
 
   public verbose(message: string) {

--- a/client/src/logging.ts
+++ b/client/src/logging.ts
@@ -57,7 +57,7 @@ export class Logger {
   }
 
   private logWithLevel(level: LogLevel, message) {
-    let logMessage = this.logLevelPrefixAsString(level) + message
+    let logMessage = this.logLevelPrefixAsString(level) + (new Date().toISOString()) + ' ' + message
 
     console.log(logMessage);
     if (level >= this.minimumUserLogLevel) {

--- a/client/src/messages.ts
+++ b/client/src/messages.ts
@@ -8,6 +8,9 @@ export interface PuppetVersionDetails {
   puppetVersion: string;
   facterVersion: string;
   languageServerVersion: string;
+  factsLoaded: boolean;
+  functionsLoaded: boolean;
+  typesLoaded: boolean;
 }
 
 export interface PuppetResourceRequestParams {

--- a/client/src/messages.ts
+++ b/client/src/messages.ts
@@ -41,6 +41,8 @@ export class PuppetCommandStrings{
   static PuppetResourceCommandId:string = 'extension.puppetResource';
   static PuppetNodeGraphToTheSideCommandId = 'extension.puppetShowNodeGraphToSide';
   static PuppetShowConnectionMenuCommandId = 'extension.puppetShowConnectionMenu';
+  static PuppetShowConnectionLogsCommandId = 'extension.puppetShowConnectionLogs';
+  static PuppetRestartSessionCommandId = 'extension.puppetRestartSession';
 }
 
 export class PDKCommandStrings {

--- a/client/src/messages.ts
+++ b/client/src/messages.ts
@@ -40,6 +40,7 @@ export interface CompileNodeGraphResponse {
 export class PuppetCommandStrings{
   static PuppetResourceCommandId:string = 'extension.puppetResource';
   static PuppetNodeGraphToTheSideCommandId = 'extension.puppetShowNodeGraphToSide';
+  static PuppetShowConnectionMenuCommandId = 'extension.puppetShowConnectionMenu';
 }
 
 export class PDKCommandStrings {

--- a/server/lib/languageserver/puppet_version.rb
+++ b/server/lib/languageserver/puppet_version.rb
@@ -1,9 +1,12 @@
 module LanguageServer
   module PuppetVersion
     # export interface PuppetVersionDetails {
-    #     puppetVersion:         string;
-    #     facterVersion:         string;
-    #     languageServerVersion: string;
+    #   puppetVersion: string;
+    #   facterVersion: string;
+    #   languageServerVersion: string;
+    #   factsLoaded: boolean;
+    #   functionsLoaded: boolean;
+    #   typesLoaded: boolean;
     # }
 
     def self.create(options)
@@ -13,6 +16,11 @@ module LanguageServer
 
       result['puppetVersion'] = options['puppetVersion']
       result['facterVersion'] = options['facterVersion']
+
+      result['factsLoaded']     = options['factsLoaded'] unless options['factsLoaded'].nil?
+      result['functionsLoaded'] = options['functionsLoaded'] unless options['functionsLoaded'].nil?
+      result['typesLoaded']     = options['typesLoaded'] unless options['typesLoaded'].nil?
+
       result['languageServerVersion'] = PuppetLanguageServer.version
 
       result

--- a/server/lib/puppet-languageserver/facter_helper.rb
+++ b/server/lib/puppet-languageserver/facter_helper.rb
@@ -1,6 +1,7 @@
 module PuppetLanguageServer
   module FacterHelper
     @ops_lock = Mutex.new
+    @facts_loaded = nil
 
     def self.reset
       @ops_lock.synchronize do
@@ -14,6 +15,10 @@ module PuppetLanguageServer
       end
     end
 
+    def self.facts_loaded?
+      @facts_loaded.nil? ? false : @facts_loaded
+    end
+
     def self.load_facts
       @ops_lock.synchronize do
         _load_facts
@@ -21,6 +26,7 @@ module PuppetLanguageServer
     end
 
     def self.facts
+      return {} if @facts_loaded == false
       @ops_lock.synchronize do
         _load_facts if @fact_hash.nil?
         @fact_hash.clone
@@ -30,6 +36,7 @@ module PuppetLanguageServer
     # DO NOT ops_lock on any of these methods
     # deadlocks will ensue!
     def self._reset
+      @facts_loaded = nil
       Facter.reset
       @fact_hash = nil
     end
@@ -40,6 +47,7 @@ module PuppetLanguageServer
       Facter.loadfacts
       @fact_hash = Facter.to_hash
       PuppetLanguageServer.log_message(:debug, "[FacterHelper::_load_facts] Finished loading #{@fact_hash.keys.count} facts")
+      @facts_loaded = true
     end
     private_class_method :_load_facts
   end

--- a/server/lib/puppet-languageserver/message_router.rb
+++ b/server/lib/puppet-languageserver/message_router.rb
@@ -43,8 +43,12 @@ module PuppetLanguageServer
         request.reply_result(nil)
 
       when 'puppet/getVersion'
-        request.reply_result(LanguageServer::PuppetVersion.create('puppetVersion' => Puppet.version,
-                                                                  'facterVersion' => Facter.version))
+        request.reply_result(LanguageServer::PuppetVersion.create('puppetVersion'   => Puppet.version,
+                                                                  'facterVersion'   => Facter.version,
+                                                                  'factsLoaded'     => PuppetLanguageServer::FacterHelper.facts_loaded?,
+                                                                  'functionsLoaded' => PuppetLanguageServer::PuppetHelper.functions_loaded?,
+                                                                  'typesLoaded'     => PuppetLanguageServer::PuppetHelper.types_loaded?
+                                                                  ))
 
       when 'puppet/getResource'
         type_name = request.params['typename']

--- a/server/spec/unit/puppet-languageserver/message_router_spec.rb
+++ b/server/spec/unit/puppet-languageserver/message_router_spec.rb
@@ -59,6 +59,21 @@ describe 'message_router' do
 
         subject.receive_request(request)
       end
+      it 'should reply with whether the facts are loaded' do
+        expect(request).to receive(:reply_result).with(hash_including('factsLoaded'))
+
+        subject.receive_request(request)
+      end
+      it 'should reply with whether the functions are loaded' do
+        expect(request).to receive(:reply_result).with(hash_including('functionsLoaded'))
+
+        subject.receive_request(request)
+      end
+      it 'should reply with whether the types are loaded' do
+        expect(request).to receive(:reply_result).with(hash_including('typesLoaded'))
+
+        subject.receive_request(request)
+      end
     end
 
     context 'given a puppet/getResource request' do


### PR DESCRIPTION
Note - This builds on https://github.com/jpogran/puppet-vscode/pull/135

Previously the Language client had no way to know whether the langauge server
had completed loading of facts, types and functions.  This caused requests to
be blocked because of mutex locks while this information is being loaded.

This commit;
- Adds three properties which the client can use to determine the loading status
  of various parts of the Language Server, with unit tests
- The puppet and facter helpers were modified to expose a *_loaded? method
- The puppet and facter helpers will now return empty datasets if they in the
  process of being loaded on another thread.  This speeds up responses to the
  client

The client will now query the language server periodically after connecting.
This query is for the load status which is shown in the UI of the extension
status bar item, until it is fully loaded.  Once loaded, the puppet version is
displayed.

Previously there was no way to restart the Language Client or view the Puppet
Client logs easily.  This commit adds a click menu which displays an option to
either restart the Lanugage Client or view the connection logs.  The location
to click is on the Language Server status bar item in the bottom right corner.

This commit changes the configuration in package.json to show the logging levels
are an enum, not free text, and adds timestamps to the log messages.