### PR TITLE
(GH-140) Show a message in Node Graph preview for zero resources

### DIFF
--- a/client/src/providers/previewNodeGraphProvider.ts
+++ b/client/src/providers/previewNodeGraphProvider.ts
@@ -79,7 +79,7 @@ export class PuppetNodeGraphContentProvider implements vscode.TextDocumentConten
             graphContent = `<textarea id="graphviz_data" style="display:none">\n` + graphContent + `\n</textarea>`;
           }
 
-          var errorContent = `<div>${compileResult.error}</div>`
+          var errorContent = `<div style='font-size: 1.5em'>${compileResult.error}</div>`
           if (compileResult.error == null) { errorContent = ''; }
           if (reporter) {
             reporter.sendTelemetryEvent(messages.PuppetCommandStrings.PuppetNodeGraphToTheSideCommandId);

--- a/server/lib/puppet-languageserver/message_router.rb
+++ b/server/lib/puppet-languageserver/message_router.rb
@@ -83,7 +83,12 @@ module PuppetLanguageServer
             'fontsize' => '""',
             'name' => 'vscode'
           }
-          dot_content = PuppetLanguageServer::PuppetParserHelper.compile_to_pretty_relationship_graph(content).to_dot(options)
+          node_graph = PuppetLanguageServer::PuppetParserHelper.compile_to_pretty_relationship_graph(content)
+          if node_graph.vertices.count.zero?
+            error_content = "There were no resources created in the node graph. Is there an include statement missing?"
+          else
+            dot_content = node_graph.to_dot(options)
+          end
         rescue => exception
           error_content = "Error while parsing the file. #{exception}"
         end


### PR DESCRIPTION
Previously if a node graph preview has no resources it just shows a blank
window which is very confusing.  This commit now shows a message in the window
saying;
`There were no resources created in the node graph. Is there an include statement
missing?`