### PR TITLE
(GH-144) Show All PDK Commands

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -151,16 +151,13 @@
           "command": "extension.pdkNewModule"
         },
         {
-          "command": "extension.pdkTestUnit",
-          "when": "resourceLangId == 'puppet'"
+          "command": "extension.pdkTestUnit"
         },
         {
-          "command": "extension.pdkValidate",
-          "when": "resourceLangId == 'puppet'"
+          "command": "extension.pdkValidate"
         },
         {
-          "command": "extension.pdkNewClass",
-          "when": "resourceLangId == 'puppet'"
+          "command": "extension.pdkNewClass"
         },
         {
           "command": "extension.puppetResource",


### PR DESCRIPTION
This commit unhides all pdk commands regardless if vscode thinks a
puppet file is open or not.

When in a window that hasn't opened a Puppet file (pp or epp), the PDK
commands are not available. This was an attempt to not show commands
that can't run without being inside a PDK module directory, but has a
side effect that after running 'pdk new module' you can't use the rest
of the pdk commands without having had run one of the commands.

This removes hiding the commands until we can research how to use the
when clause better.