### PR TITLE
(GH-140) Fix unit tests for zero resource node graph

### DIFF
--- a/server/spec/spec_helper.rb
+++ b/server/spec/spec_helper.rb
@@ -55,6 +55,12 @@ class MockJSONRPCHandler < PuppetLanguageServer::JSONRPCHandler
   end
 end
 
+class MockRelationshipGraph
+  attr_accessor :vertices
+  def initialize()
+  end
+end
+
 class MockResource
   attr_accessor :title
 


### PR DESCRIPTION
Previously in commit 30e8fecb683 an error message was raised for node graphs
with no resources however the unit tests were not modified for this scenario.
This commit updates the unit tests for these test scenarios.