### PR TITLE
(GH-116) Fix packaging to conform with vsce workflow

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.0.4-appv.{build}
+version: 0.7.0-appv.{build}
 clone_depth: 10
 init:
 - SET
@@ -32,7 +32,7 @@ environment:
   # Package it up to a VSIX
   - nodejs_version: "7.4.0"
     nodejs_arch: "x64"
-    GULP_BUILD_TASK: build
+    VSCE_TASK: package
 
 matrix:
   fast_finish: true
@@ -75,6 +75,9 @@ install:
        Write-Host "npm Version..."
        & npm --version
 
+       Write-Host "Installing VSCE globally..."
+       & npm install -g vsce --silent
+
        Write-Host "Installing modules..."
        & npm install --silent
 
@@ -84,6 +87,7 @@ install:
 
 build_script:
 - cmd: IF NOT [%GULP_BUILD_TASK%] == [] node node_modules\gulp\bin\gulp.js %GULP_BUILD_TASK%
+- cmd: IF NOT [%VSCE_TASK%] == [] vsce %VSCE_TASK%
 
 test_script:
 - cmd: IF NOT [%RAKE_TASK%] == [] bundle exec rake %RAKE_TASK%

--- a/client/gulpfile.js
+++ b/client/gulpfile.js
@@ -21,8 +21,8 @@ gulp.task('copy_language_server', function () {
              .pipe(gulp.dest('./vendor/languageserver'));
 })
 
-gulp.task('build_extension', function (callback) {
-  exec('node ./node_modules/vsce/out/vsce package',
+gulp.task('compile_typescript', function (callback) {
+  exec('tsc -p ./',
     function (err, stdout, stderr) {
       console.log(stdout);
       console.log(stderr);
@@ -32,7 +32,7 @@ gulp.task('build_extension', function (callback) {
 
 
 gulp.task('build', function (callback) {
-  runSequence('clean','copy_language_server','build_extension',callback);
+  runSequence('clean','copy_language_server','compile_typescript',callback);
 })
 
 gulp.task('bump', function () {

--- a/client/package.json
+++ b/client/package.json
@@ -289,7 +289,7 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "tsc -p ./",
+    "vscode:prepublish": "node node_modules/gulp/bin/gulp.js build",
     "compile": "tsc -p ./",
     "compile-watch": "tsc -watch -p ./",
     "postinstall": "node ./node_modules/vscode/bin/install",


### PR DESCRIPTION
Previously the gulp file could be used to package the extension however that is
not how the VS Code Extension tool workflow operates (vsce).  This commit
changes the tool chain so that vsce calls the gulpfile during pre-publish to
ensure the language server is updated prior to packaging.