### PR TITLE
(GH-157) Activate Puppet Resource Command

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -161,7 +161,7 @@
         },
         {
           "command": "extension.puppetResource",
-          "when": "editorTextFocus && editorLangId == 'puppet'"
+          "when": "resourceLangId == 'puppet'"
         },
         {
           "command": "extension.puppetShowNodeGraphToSide",


### PR DESCRIPTION
Due to the when clause used in the command palette setup for the  command, it was hidden from view to the user but available to be invoked. This commit changes visibility so now its viewable to the user