### PR TITLE
(GH-88) Use local Graph Renderer for node graphs

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -309,6 +309,7 @@
   },
   "dependencies": {
     "vscode-languageclient": "~3.3.0",
-    "vscode-extension-telemetry": "^0.0.6"
+    "vscode-extension-telemetry": "^0.0.6",
+    "viz.js":"~1.8.0"
   }
 }


### PR DESCRIPTION
Previously the Node Graph preview was calling out to an external website to do
it's graph rendering.  This commit uses a local node module to do the rendering
and removes the temporary external website method.

This fixes #88 