### PR TITLE
(GH-97) Create a crash file when the language server abends

### DIFF
--- a/server/lib/puppet-languageserver/message_router.rb
+++ b/server/lib/puppet-languageserver/message_router.rb
@@ -19,6 +19,57 @@ module PuppetLanguageServer
       return nil if @documents[uri].nil?
       @documents[uri].clone
     end
+
+    def self.document_uris
+      @documents.keys.dup
+    end
+  end
+
+  module CrashDump
+    def self.default_crash_file
+      File.join(Dir.tmpdir(),'puppet_language_server_crash.txt')
+    end
+
+    def self.write_crash_file(err, filename = nil, additional = {})
+      # Create the crash text
+
+      puppet_version         = Puppet.version rescue 'Unknown'
+      facter_version         = Facter.version rescue 'Unknown'
+      languageserver_version = PuppetLanguageServer.version rescue 'Unknown'
+
+      crashtext = <<-TEXT
+Puppet Language Server Crash File
+-=--=--=--=--=--=--=--=--=--=--=-
+#{DateTime.now.strftime("%a %b %e %Y %H:%M:%S %Z")}
+Puppet Version #{puppet_version}
+Facter Version #{facter_version}
+Ruby Version #{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}
+Language Server Version #{languageserver_version}
+
+Error: #{err.to_s}
+
+Backtrace
+---------
+#{err.backtrace.join("\n") }
+
+TEXT
+      # Append the documents in the cache
+      PuppetLanguageServer::DocumentStore.document_uris.each do |uri|
+        crashtext += "Document - #{uri}\n---\n#{PuppetLanguageServer::DocumentStore.document(uri)}\n\n"
+      end
+      # Append additional objects from the crash
+      additional.each do |k,v|
+        crashtext += "#{k}\n---\n#{v.to_s}\n\n"
+      end
+
+      crash_file = filename.nil? ? default_crash_file : filename
+      File.open(crash_file, 'wb') { |file| file.write(crashtext) }
+    rescue
+      # Swallow all errors.  Errors in the error handler should not
+      # terminate the application
+    end
+
+    nil
   end
 
   class MessageRouter < JSONRPCHandler
@@ -134,6 +185,12 @@ module PuppetLanguageServer
       else
         PuppetLanguageServer.log_message(:error, "Unknown RPC method #{request.rpc_method}")
       end
+    rescue => err
+      PuppetLanguageServer::CrashDump.write_crash_file(err, nil, {
+        'request' => request.rpc_method,
+        'params'  => request.params,
+      })
+      raise
     end
 
     def receive_notification(method, params)
@@ -170,6 +227,12 @@ module PuppetLanguageServer
       else
         PuppetLanguageServer.log_message(:error, "Unknown RPC notification #{method}")
       end
+    rescue => err
+      PuppetLanguageServer::CrashDump.write_crash_file(err, nil, {
+        'notification' => method,
+        'params'  => params,
+      })
+      raise
     end
   end
 end

--- a/server/spec/integration/puppet-languageserver/message_router_spec.rb
+++ b/server/spec/integration/puppet-languageserver/message_router_spec.rb
@@ -1,0 +1,160 @@
+require 'spec_helper'
+
+describe 'message_router' do
+  let(:subject_options) { nil }
+  let(:subject) { PuppetLanguageServer::MessageRouter.new(subject_options) }
+
+  describe '#receive_request' do
+    let(:documents) {{
+      'file1.rb' => "file1_line1\nfile1_line2\nfile1_line3\nfile1_line4\n"
+    }}
+    let(:request_connection) { MockJSONRPCHandler.new() }
+    let(:request_rpc_method) { nil }
+    let(:request_params) { { 'crashparam1' => 'crashvalue1'} }
+    let(:request_id) { 0 }
+    let(:request) { PuppetLanguageServer::JSONRPCHandler::Request.new(
+      request_connection,request_id,request_rpc_method,request_params) }
+
+    before(:each) do
+      allow(PuppetLanguageServer).to receive(:log_message)
+
+      # Populate the document cache
+      PuppetLanguageServer::DocumentStore.clear
+      documents.each { |uri, content| PuppetLanguageServer::DocumentStore.set_document(uri, content) }
+    end
+
+    context 'given a request that raises an error' do
+      let(:request_rpc_method) { 'puppet/getVersion' }
+      before(:each) do
+        @default_crash_file = PuppetLanguageServer::CrashDump.default_crash_file
+        File.delete(@default_crash_file) if File.exists?(@default_crash_file)
+
+        expect(Puppet).to receive(:version).at_least(:once).and_raise('MockError')
+      end
+
+      it 'should create a default crash dump file' do
+        begin
+          subject.receive_request(request)
+        rescue
+        end
+
+        expect(File.exists?(@default_crash_file)).to be(true)
+      end
+
+      context 'the content of the crash dump file' do
+        before(:each) do
+          # Force a crash dump to occur
+          begin
+            subject.receive_request(request)
+          rescue
+          end
+          @crash_content = File.open(@default_crash_file, 'rb') { |file| file.read }
+        end
+
+        it 'should contain the error text' do
+          expect(@crash_content).to match(/Error: MockError/)
+        end
+
+        it 'should contain a backtrace' do
+          expect(@crash_content).to match(/Backtrace/)
+          expect(@crash_content).to match(/message_router.rb/)
+        end
+
+        it 'should contain the request method' do
+          expect(@crash_content).to match(/request/)
+          expect(@crash_content).to match(request_rpc_method)
+        end
+
+        it 'should contain the current document cache' do
+          documents.each do |uri,content|
+            expect(@crash_content).to match(uri)
+            expect(@crash_content).to match(content)
+          end
+        end
+
+        it 'should contain the request parameters' do
+          expect(@crash_content).to match(/params/)
+          request_params.each do |k,v|
+            expect(@crash_content).to match(k)
+            expect(@crash_content).to match(v)
+          end
+        end
+      end
+    end
+  end
+
+  describe '#receive_notification' do
+    let(:documents) {{
+      'file1.rb' => "file1_line1\nfile1_line2\nfile1_line3\nfile1_line4\n"
+    }}
+    let(:notification_method) { nil }
+    let(:notification_params) { { 'crashparam2' => 'crashvalue2'} }
+
+    before(:each) do
+      allow(PuppetLanguageServer).to receive(:log_message)
+
+      # Populate the document cache
+      PuppetLanguageServer::DocumentStore.clear
+      documents.each { |uri, content| PuppetLanguageServer::DocumentStore.set_document(uri, content) }
+    end
+
+    context 'given a request that raises an error' do
+      let(:notification_method) { 'exit' }
+      before(:each) do
+        @default_crash_file = PuppetLanguageServer::CrashDump.default_crash_file
+        File.delete(@default_crash_file) if File.exists?(@default_crash_file)
+
+        expect(subject).to receive(:close_connection).and_raise('MockError')
+      end
+
+      it 'should create a default crash dump file' do
+        begin
+          subject.receive_notification(notification_method, notification_params)
+        rescue
+        end
+
+        expect(File.exists?(@default_crash_file)).to be(true)
+      end
+
+      context 'the content of the crash dump file' do
+        before(:each) do
+          # Force a crash dump to occur
+          begin
+            subject.receive_notification(notification_method, notification_params)
+          rescue
+          end
+          @crash_content = File.open(@default_crash_file, 'rb') { |file| file.read }
+        end
+
+        it 'should contain the error text' do
+          expect(@crash_content).to match(/Error: MockError/)
+        end
+
+        it 'should contain a backtrace' do
+          expect(@crash_content).to match(/Backtrace/)
+          expect(@crash_content).to match(/message_router.rb/)
+        end
+
+        it 'should contain the notification name' do
+          expect(@crash_content).to match(/notification/)
+          expect(@crash_content).to match(notification_method)
+        end
+
+        it 'should contain the current document cache' do
+          documents.each do |uri,content|
+            expect(@crash_content).to match(uri)
+            expect(@crash_content).to match(content)
+          end
+        end
+
+        it 'should contain the request parameters' do
+          expect(@crash_content).to match(/params/)
+          notification_params.each do |k,v|
+            expect(@crash_content).to match(k)
+            expect(@crash_content).to match(v)
+          end
+        end
+      end
+    end
+  end
+end

--- a/server/spec/unit/puppet-languageserver/message_router_spec.rb
+++ b/server/spec/unit/puppet-languageserver/message_router_spec.rb
@@ -22,6 +22,23 @@ describe 'message_router' do
       allow(PuppetLanguageServer).to receive(:log_message)
     end
 
+    context 'given a request that raises an error' do
+      let(:request_rpc_method) { 'puppet/getVersion' }
+      before(:each) do
+        expect(Puppet).to receive(:version).and_raise('MockError')
+        allow(PuppetLanguageServer::CrashDump).to receive(:write_crash_file)
+      end
+
+      it 'should raise an error' do
+        expect{ subject.receive_request(request) }.to raise_error(/MockError/)
+      end
+
+      it 'should call PuppetLanguageServer::CrashDump.write_crash_file' do
+        expect(PuppetLanguageServer::CrashDump).to receive(:write_crash_file)
+        expect{ subject.receive_request(request) }.to raise_error(/MockError/)
+      end
+    end
+
     # initialize - https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialize
     context 'given an initialize request' do
       let(:request_rpc_method) { 'initialize' } 
@@ -385,6 +402,23 @@ describe 'message_router' do
   describe '#receive_notification' do
     let(:notification_method) { nil }
     let(:notification_params) { {} }
+
+    context 'given a notification that raises an error' do
+      let(:notification_method) { 'exit' }
+      before(:each) do
+        expect(subject).to receive(:close_connection).and_raise('MockError')
+        allow(PuppetLanguageServer::CrashDump).to receive(:write_crash_file)
+      end
+
+      it 'should raise an error' do
+        expect{ subject.receive_notification(notification_method, notification_params) }.to raise_error(/MockError/)
+      end
+
+      it 'should call PuppetLanguageServer::CrashDump.write_crash_file' do
+        expect(PuppetLanguageServer::CrashDump).to receive(:write_crash_file)
+        expect{ subject.receive_notification(notification_method, notification_params) }.to raise_error(/MockError/)
+      end
+    end
 
     # initialized - https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md#initialized
     context 'given an initialized notification' do


### PR DESCRIPTION
Previously when the language server crashed, no debug information would be
created which would make it difficult to diagnose issues in the field.  This
commit adds the facility to create a crash file in
%TMP%\puppet_language_server_crash.txt.

This commit also adds tests for this facility. #97 