### PR TITLE
(GH-169) Fix colourisation of comments in class params

### DIFF
--- a/client/syntaxes/puppet.tmLanguage
+++ b/client/syntaxes/puppet.tmLanguage
@@ -69,6 +69,10 @@
           <string>#numbers</string>
         </dict>
         <dict>
+          <key>include</key>
+          <string>#line_comment</string>
+        </dict>
+        <dict>
           <key>begin</key>
           <string>\b(inherits)\b\s+</string>
           <key>captures</key>


### PR DESCRIPTION
Previously the sytnax highlighter would not highlight comments in the class
parameters section correctly.  This was compounded further if an apostrophe
was used in the comments, the highlighter would then mark the remainder of the
document as a string.  This commit adds the line_comment pattern to be available
when inside a class (or node) header definition.  The header is everything from
the word `class` to the first brace `{`.