### PR TITLE
(docs)(maint) Replace all docs.puppet.com URLs

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -11,9 +11,9 @@ This extension provides full Puppet Language support for [Visual Studio Code](ht
 
 You will need to have Puppet Agent installed in order to fully use this extension. You can find instructions and installation links here:
 
-* [Windows](https://docs.puppet.com/puppet/latest/install_windows.html)
-* [MacOSX](https://docs.puppet.com/puppet/latest/install_osx.html)
-* [Linux](https://docs.puppet.com/puppet/latest/install_linux.html)
+* [Windows](https://puppet.com/docs/puppet/latest/install_windows.html)
+* [MacOSX](https://puppet.com/docs/puppet/latest/install_osx.html)
+* [Linux](https://puppet.com/docs/puppet/latest/install_linux.html)
 
 ## Quick start
 

--- a/server/README.md
+++ b/server/README.md
@@ -73,11 +73,11 @@ I, [2017-06-08T13:23:40.474286 #18496]  INFO -- : Preloading Functions (Async)..
 
 * Ensure that Puppet Agent is installed
 
-[Linux](https://docs.puppet.com/puppet/4.10/install_linux.html)
+[Linux](https://puppet.com/docs/puppet/latest/install_linux.html)
 
-[Windows](https://docs.puppet.com/puppet/4.10/install_windows.html)
+[Windows](https://puppet.com/docs/puppet/latest/install_windows.html)
 
-[MacOSX](https://docs.puppet.com/puppet/4.10/install_osx.html)
+[MacOSX](https://puppet.com/docs/puppet/latest/install_osx.html)
 
 
 * Clone this repository

--- a/server/vendor/puppet-lint/README.md
+++ b/server/vendor/puppet-lint/README.md
@@ -5,7 +5,7 @@ Status](https://secure.travis-ci.org/rodjek/puppet-lint.png)](http://travis-ci.o
 [![Inline docs](http://inch-ci.org/github/rodjek/puppet-lint.png?branch=master)](http://inch-ci.org/github/rodjek/puppet-lint)
 
 Puppet Lint tests Puppet code against the recommended [Puppet language style
-guide](http://docs.puppet.com/puppet/latest/style_guide.html). Puppet Lint validates only code style; it does not validate syntax. To test syntax, use Puppet's `puppet parser validate` command.
+guide](https://puppet.com/docs/puppet/latest/style_guide.html). Puppet Lint validates only code style; it does not validate syntax. To test syntax, use Puppet's `puppet parser validate` command.
 
 ## Compatibility warning
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for chaining arrow that is
 # on the line of the left operand when the right operand is on another line.
 #
-# https://docs.puppet.com/guides/style_guide.html#chaining-arrow-syntax
+# https://puppet.com/docs/puppet/latest/style_guide.html#chaining-arrow-syntax
 PuppetLint.new_check(:arrow_on_right_operand_line) do
   def check
     tokens.select { |r| Set[:IN_EDGE, :IN_EDGE_SUB].include?(r.type) }.each do |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/autoloader_layout.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/autoloader_layout.rb
@@ -2,7 +2,7 @@
 # not in an appropriately named file for the autoloader to detect and record
 # an error of each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#separate-files
+# https://puppet.com/docs/puppet/latest/style_guide.html#separate-files
 PuppetLint.new_check(:autoloader_layout) do
   def check
     unless fullpath.nil? || fullpath == ''

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/inherits_across_namespaces.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/inherits_across_namespaces.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for any classes that inherit across
 # namespaces and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#class-inheritance
+# https://puppet.com/docs/puppet/latest/style_guide.html#class-inheritance
 PuppetLint.new_check(:inherits_across_namespaces) do
   def check
     class_indexes.each do |class_idx|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/names_containing_uppercase.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/names_containing_uppercase.rb
@@ -1,6 +1,6 @@
 # Public: Find and warn about module names with illegal uppercase characters.
 #
-# https://docs.puppet.com/puppet/latest/reference/modules_fundamentals.html#allowed-module-names
+# https://puppet.com/docs/puppet/latest/modules_fundamentals.html#allowed-module-names
 # Provides a fix. [puppet-lint #554]
 PuppetLint.new_check(:names_containing_uppercase) do
   def check

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/nested_classes_or_defines.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/nested_classes_or_defines.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for any classes or defined types that are
 # defined inside another class.
 #
-# https://docs.puppet.com/guides/style_guide.html#nested-classes-or-defined-types
+# https://puppet.com/docs/puppet/latest/style_guide.html#nested-classes-or-defined-types
 PuppetLint.new_check(:nested_classes_or_defines) do
   TOKENS = Set[:CLASS, :DEFINE]
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/parameter_order.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/parameter_order.rb
@@ -2,7 +2,7 @@
 # types that take parameters and record a warning if there are any optional
 # parameters listed before required parameters.
 #
-# https://docs.puppet.com/guides/style_guide.html#display-order-of-parameters
+# https://puppet.com/docs/puppet/latest/style_guide.html#display-order-of-parameters
 PuppetLint.new_check(:parameter_order) do
   def check
     (class_indexes + defined_type_indexes).each do |class_idx|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/right_to_left_relationship.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/right_to_left_relationship.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for any right-to-left (<-) chaining
 # operators and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#chaining-arrow-syntax
+# https://puppet.com/docs/puppet/latest/style_guide.html#chaining-arrow-syntax
 PuppetLint.new_check(:right_to_left_relationship) do
   def check
     tokens.select { |r| r.type == :OUT_EDGE }.each do |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/variable_scope.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/variable_scope.rb
@@ -4,7 +4,7 @@
 # defined in the local scope and record a warning for each variable that has
 # not.
 #
-# https://docs.puppet.com/guides/style_guide.html#namespacing-variables
+# https://puppet.com/docs/puppet/latest/style_guide.html#namespacing-variables
 PuppetLint.new_check(:variable_scope) do
   DEFAULT_SCOPE_VARS = Set[
     'name',

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_comments/slash_comments.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_comments/slash_comments.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any comments started with slashes
 # (//) and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#comments
+# https://puppet.com/docs/puppet/latest/style_guide.html#comments
 PuppetLint.new_check(:slash_comments) do
   def check
     tokens.select { |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_comments/star_comments.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_comments/star_comments.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any comments encapsulated with
 # slash-asterisks (/* */) and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#comments
+# https://puppet.com/docs/puppet/latest/style_guide.html#comments
 PuppetLint.new_check(:star_comments) do
   def check
     tokens.select { |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_conditionals/case_without_default.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_conditionals/case_without_default.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for any case statements that do not
 # contain a "default" case and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#defaults-for-case-statements-and-selectors
+# https://puppet.com/docs/puppet/latest/style_guide.html#defaults-for-case-statements-and-selectors
 PuppetLint.new_check(:case_without_default) do
   def check
     case_indexes = []

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_conditionals/selector_inside_resource.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_conditionals/selector_inside_resource.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for any selectors embedded within resource
 # declarations and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#keep-resource-declarations-simple
+# https://puppet.com/docs/puppet/latest/style_guide.html#keep-resource-declarations-simple
 PuppetLint.new_check(:selector_inside_resource) do
   def check
     resource_indexes.each do |resource|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_documentation/documentation.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_documentation/documentation.rb
@@ -2,7 +2,7 @@
 # have a comment directly above it (hopefully, explaining the usage of it) and
 # record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#public-and-private
+# https://puppet.com/docs/puppet/latest/style_guide.html#public-and-private
 PuppetLint.new_check(:documentation) do
   COMMENT_TOKENS = Set[:COMMENT, :MLCOMMENT, :SLASH_COMMENT]
   WHITESPACE_TOKENS = Set[:WHITESPACE, :NEWLINE, :INDENT]

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/ensure_first_param.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/ensure_first_param.rb
@@ -2,7 +2,7 @@
 # and if found, check that it is the first parameter listed.  If it is not
 # the first parameter, record a warning.
 #
-# https://docs.puppet.com/guides/style_guide.html#attribute-ordering
+# https://puppet.com/docs/puppet/latest/style_guide.html#attribute-ordering
 PuppetLint.new_check(:ensure_first_param) do
   def check
     resource_indexes.each do |resource|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/ensure_not_symlink_target.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/ensure_not_symlink_target.rb
@@ -2,7 +2,7 @@
 # parameter and record a warning if the value of that parameter looks like
 # a symlink target (starts with a '/').
 #
-# https://docs.puppet.com/guides/style_guide.html#symbolic-links
+# https://puppet.com/docs/puppet/latest/style_guide.html#symbolic-links
 PuppetLint.new_check(:ensure_not_symlink_target) do
   def check
     resource_indexes.each do |resource|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/file_mode.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/file_mode.rb
@@ -2,7 +2,7 @@
 # parameter and if found, record a warning if the value of that parameter is
 # not a 4 digit octal value (0755) or a symbolic mode ('o=rwx,g+r').
 #
-# https://docs.puppet.com/guides/style_guide.html#file-modes
+# https://puppet.com/docs/puppet/latest/style_guide.html#file-modes
 PuppetLint.new_check(:file_mode) do
   MSG = 'mode should be represented as a 4 digit octal value or symbolic mode'
   SYM_RE = "([ugoa]*[-=+][-=+rstwxXugo]*)(,[ugoa]*[-=+][-=+rstwxXugo]*)*"

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/unquoted_file_mode.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/unquoted_file_mode.rb
@@ -2,7 +2,7 @@
 # parameter and if found, record a warning if the value of that parameter is
 # not a quoted string.
 #
-# https://docs.puppet.com/guides/style_guide.html#file-modes
+# https://puppet.com/docs/puppet/latest/style_guide.html#file-modes
 PuppetLint.new_check(:unquoted_file_mode) do
   TOKEN_TYPES = Set[:NAME, :NUMBER]
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/unquoted_resource_title.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/unquoted_resource_title.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any resource titles / namevars that
 # are not quoted and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#resource-names
+# https://puppet.com/docs/puppet/latest/style_guide.html#resource-names
 PuppetLint.new_check(:unquoted_resource_title) do
   def check
     title_tokens.each do |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/double_quoted_strings.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/double_quoted_strings.rb
@@ -2,7 +2,7 @@
 # contain any variables or common escape characters and record a warning for
 # each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#quoting
+# https://puppet.com/docs/puppet/latest/style_guide.html#quoting
 PuppetLint.new_check(:double_quoted_strings) do
   def check
     tokens.select { |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/only_variable_string.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/only_variable_string.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for double quoted strings that contain
 # a single variable only and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#quoting
+# https://puppet.com/docs/puppet/latest/style_guide.html#quoting
 PuppetLint.new_check(:only_variable_string) do
   VAR_TYPES = Set[:VARIABLE, :UNENC_VARIABLE]
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/single_quote_string_with_variables.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/single_quote_string_with_variables.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any single quoted strings containing
 # a enclosed variable and record an error for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#quoting
+# https://puppet.com/docs/puppet/latest/style_guide.html#quoting
 PuppetLint.new_check(:single_quote_string_with_variables) do
   def check
     tokens.select { |r|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/variables_not_enclosed.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/variables_not_enclosed.rb
@@ -2,7 +2,7 @@
 # not been enclosed by braces ({}) and record a warning for each instance
 # found.
 #
-# https://docs.puppet.com/guides/style_guide.html#quoting
+# https://puppet.com/docs/puppet/latest/style_guide.html#quoting
 PuppetLint.new_check(:variables_not_enclosed) do
   def check
     tokens.select { |r|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/140chars.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/140chars.rb
@@ -3,7 +3,7 @@
 # to this rule are lines containing URLs and template() calls which would hurt
 # readability if split.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
 PuppetLint.new_check(:'140chars') do
   def check
     manifest_lines.each_with_index do |line, idx|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/2sp_soft_tabs.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/2sp_soft_tabs.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any indentation not using 2 space soft
 # tabs and record an error for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
 PuppetLint.new_check(:'2sp_soft_tabs') do
   def check
     tokens.select { |r|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/80chars.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/80chars.rb
@@ -2,7 +2,7 @@
 # characters. This is DISABLED by default and behaves like the default
 # 140chars check by excepting URLs and template() calls.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace (older version)
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace (older version)
 PuppetLint.new_check(:'80chars') do
   def check
     manifest_lines.each_with_index do |line, idx|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/arrow_alignment.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/arrow_alignment.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any arrows (=>) in a grouping ({}) that
 # are not aligned with other arrows in that grouping.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
 PuppetLint.new_check(:arrow_alignment) do
   COMMENT_TYPES = Set[:COMMENT, :SLASH_COMMENT, :MLCOMMENT]
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/hard_tabs.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/hard_tabs.rb
@@ -1,7 +1,7 @@
 # Public: Check the raw manifest string for lines containing hard tab
 # characters and record an error for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
 PuppetLint.new_check(:hard_tabs) do
   WHITESPACE_TYPES = Set[:INDENT, :WHITESPACE]
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for lines ending with whitespace and record
 # an error for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
 PuppetLint.new_check(:trailing_whitespace) do
   def check
     tokens.select { |token|


### PR DESCRIPTION
 with new corresponding puppet.com/docs URLs.
During puppetconf this year, the current versions of docs were moved from their own URL (docs.puppet.com) to puppet.com/docs.

I tried to test out each replacement as I updated, they all appear to be working. There are of course redirects in place for these so I don't think any are currently 404ing as-is, but it's preferred we update the links and references themselves where possible.