### PR TITLE
(GH-177) Remove version file detection

### DIFF
--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -265,13 +265,6 @@ export class ConnectionManager implements IConnectionManager {
         result.options.shell = true;
         break;
     }
-    // Check if this really is a Puppet Agent installation
-    if (!fs.existsSync(path.join(puppetAgentDir, "VERSION"))) {
-      this.logger.debug(logPrefix + "Could not find a valid Puppet Agent installation at " + puppetAgentDir);
-      return null;
-    } else {
-      this.logger.debug(logPrefix + "Found a valid Puppet Agent installation at " + puppetAgentDir);
-    }
 
     let puppetDir = path.join(puppetAgentDir,"puppet");
     let facterDir = path.join(puppetAgentDir,"facter");


### PR DESCRIPTION
This commit removes the check for the VERSION file inside the puppet
agent install path. This was originally used as a check that you had a
valid Puppet Agent path specified, but since there are variances whether
the file exists or not or where it's located in each package for each
platform, and it doesn't provide any actual value, it makes sense to
remove it.