### PR TITLE
(GH-180) Display backslashes in node graph

### DIFF
--- a/client/src/providers/previewNodeGraphProvider.ts
+++ b/client/src/providers/previewNodeGraphProvider.ts
@@ -76,6 +76,9 @@ export class PuppetNodeGraphContentProvider implements vscode.TextDocumentConten
             label = ""`
 
             var graphContent = compileResult.dotContent;
+            // vis.jz sees backslashes as escape characters, however they are not in the DOT language.  Instead
+            // we should escape any backslash coming from a valid DOT file in preparation to be rendered
+            graphContent = graphContent.replace(/\\/g,"\\\\");
             graphContent = graphContent.replace(`label = "vscode"`,styling);
 
             svgContent = viz(graphContent,"svg");


### PR DESCRIPTION
Previously vis.jz sees backslashes as escape characters, however they are not in
the DOT language.  This commit escapes any backslash (double backslash) coming
from a valid DOT file, in preparation to be rendered by viz.js.