### PR TITLE
(GH-166) Add find/peek definition capability to language server

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -33,6 +33,7 @@ Create or open any Puppet manifest with the extension `.pp` or `.epp` and the ex
 - Code snippets
 - Linting
 - IntelliSense for resources, parameters and more
+- Go to Definition of functions, types and classes
 - Validation of `metadata.json` files
 - Import from `puppet resource` directly into manifests
 - Node graph preview

--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -281,18 +281,19 @@ export class ConnectionManager implements IConnectionManager {
         // After 30 seonds timeout the progress
         if (count >= 30 || connectionManager.languageClient == undefined) {
           clearInterval(handle);
-          connectionManager.setConnectionStatus(lastVersionResponse.puppetVersion, ConnectionStatus.Running);
+          this.setConnectionStatus(lastVersionResponse.puppetVersion, ConnectionStatus.Running);
           resolve();
+          return;
         }
 
         connectionManager.languageClient.sendRequest(messages.PuppetVersionRequest.type).then((versionDetails) => {
           lastVersionResponse = versionDetails
-          if (versionDetails.factsLoaded &&
+          if (!connectionManager.connectionConfiguration.preLoadPuppet || (versionDetails.factsLoaded &&
               versionDetails.functionsLoaded &&
               versionDetails.typesLoaded &&
-              versionDetails.classesLoaded) {
+              versionDetails.classesLoaded)) {
             clearInterval(handle);
-            connectionManager.setConnectionStatus(lastVersionResponse.puppetVersion, ConnectionStatus.Running);
+            this.setConnectionStatus(lastVersionResponse.puppetVersion, ConnectionStatus.Running);
             resolve();
           } else {
             let progress = 0;
@@ -358,6 +359,7 @@ export class ConnectionManager implements IConnectionManager {
   }
 
   private setConnectionStatus(statusText: string, status: ConnectionStatus): void {
+    console.log(statusText)
     // Set color and icon for 'Running' by default
     var statusIconText = "$(terminal) ";
     var statusColor = "#affc74";

--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -287,7 +287,10 @@ export class ConnectionManager implements IConnectionManager {
 
         connectionManager.languageClient.sendRequest(messages.PuppetVersionRequest.type).then((versionDetails) => {
           lastVersionResponse = versionDetails
-          if (versionDetails.factsLoaded && versionDetails.functionsLoaded && versionDetails.typesLoaded) {
+          if (versionDetails.factsLoaded &&
+              versionDetails.functionsLoaded &&
+              versionDetails.typesLoaded &&
+              versionDetails.classesLoaded) {
             clearInterval(handle);
             connectionManager.setConnectionStatus(lastVersionResponse.puppetVersion, ConnectionStatus.Running);
             resolve();
@@ -297,7 +300,8 @@ export class ConnectionManager implements IConnectionManager {
             if (versionDetails.factsLoaded) { progress++; }
             if (versionDetails.functionsLoaded) { progress++; }
             if (versionDetails.typesLoaded) { progress++; }
-            progress = Math.round(progress / 3.0 * 100);
+            if (versionDetails.classesLoaded) { progress++; }
+            progress = Math.round(progress / 4.0 * 100);
 
             this.setConnectionStatus("Loading Puppet (" + progress.toString() + "%)", ConnectionStatus.Starting);
           }

--- a/client/src/messages.ts
+++ b/client/src/messages.ts
@@ -11,6 +11,7 @@ export interface PuppetVersionDetails {
   factsLoaded: boolean;
   functionsLoaded: boolean;
   typesLoaded: boolean;
+  classesLoaded: boolean;
 }
 
 export interface PuppetResourceRequestParams {

--- a/server/lib/languageserver/languageserver.rb
+++ b/server/lib/languageserver/languageserver.rb
@@ -1,4 +1,4 @@
-%w[constants diagnostic completion_list completion_item hover puppet_version puppet_compilation].each do |lib|
+%w[constants diagnostic completion_list completion_item hover location puppet_version puppet_compilation].each do |lib|
   begin
     require "languageserver/#{lib}"
   rescue LoadError

--- a/server/lib/languageserver/location.rb
+++ b/server/lib/languageserver/location.rb
@@ -1,0 +1,30 @@
+module LanguageServer
+  #  /**
+  #  * The result of a hover request.
+  #  */
+  # export interface Location {
+  #   uri: string;
+  #   range: Range;
+  # }
+
+  module Location
+    def self.create(options)
+      result = {}
+      raise('uri is a required field for Location') if options['uri'].nil?
+
+      result['uri'] = options['uri']
+      result['range'] = {
+        'start' => {
+          'line' => options['fromline'],
+          'character' => options['fromchar']
+        },
+        'end' => {
+          'line'      => options['toline'],
+          'character' => options['tochar']
+        }
+      }
+
+      result
+    end
+  end
+end

--- a/server/lib/languageserver/puppet_version.rb
+++ b/server/lib/languageserver/puppet_version.rb
@@ -7,6 +7,7 @@ module LanguageServer
     #   factsLoaded: boolean;
     #   functionsLoaded: boolean;
     #   typesLoaded: boolean;
+    #   classesLoaded: boolean;
     # }
 
     def self.create(options)
@@ -20,7 +21,8 @@ module LanguageServer
       result['factsLoaded']     = options['factsLoaded'] unless options['factsLoaded'].nil?
       result['functionsLoaded'] = options['functionsLoaded'] unless options['functionsLoaded'].nil?
       result['typesLoaded']     = options['typesLoaded'] unless options['typesLoaded'].nil?
-
+      result['classesLoaded']   = options['classesLoaded'] unless options['classesLoaded'].nil?
+      
       result['languageServerVersion'] = PuppetVSCode.version
 
       result

--- a/server/lib/puppet-languageserver.rb
+++ b/server/lib/puppet-languageserver.rb
@@ -5,8 +5,8 @@ begin
   require 'languageserver/languageserver'
   require 'puppet-vscode'
 
-  %w[json_rpc_handler message_router server_capabilities document_validator
-    puppet_parser_helper puppet_helper facter_helper completion_provider hover_provider].each do |lib|
+  %w[json_rpc_handler message_router server_capabilities document_validator puppet_parser_helper puppet_helper 
+    facter_helper completion_provider hover_provider definition_provider puppet_monkey_patches].each do |lib|
     begin
       require "puppet-languageserver/#{lib}"
     rescue LoadError
@@ -126,6 +126,9 @@ module PuppetLanguageServer
 
       log_message(:info, 'Preloading Functions (Async)...')
       PuppetLanguageServer::PuppetHelper.load_functions_async
+
+      log_message(:info, 'Preloading Classes (Async)...')
+      PuppetLanguageServer::PuppetHelper.load_classes_async
     else
       log_message(:info, 'Skipping preloading Puppet')
     end

--- a/server/lib/puppet-languageserver/definition_provider.rb
+++ b/server/lib/puppet-languageserver/definition_provider.rb
@@ -1,0 +1,83 @@
+module PuppetLanguageServer
+  module DefinitionProvider
+    def self.find_definition(content, line_num, char_num)
+      result = PuppetLanguageServer::PuppetParserHelper.object_under_cursor(content, line_num, char_num, false, [Puppet::Pops::Model::BlockExpression])
+
+      return nil if result.nil?
+
+      path = result[:path]
+      item = result[:model]
+
+      response = []
+      case item.class.to_s
+      when 'Puppet::Pops::Model::CallNamedFunctionExpression'
+        func_name = item.functor_expr.value
+        response << function_name(resource_name)
+
+      when 'Puppet::Pops::Model::QualifiedName'
+        # Qualified names could be anything.  Context is the key here
+        parent = path.last
+
+        # What if it's a function name.  Then the Qualified name must be the same as the function name
+        if !parent.nil? &&
+          parent.class.to_s == 'Puppet::Pops::Model::CallNamedFunctionExpression' &&
+          parent.functor_expr.value == item.value
+            func_name = item.value
+            response << function_name(func_name)
+        end
+        # What if it's an "include <class>" call
+        if !parent.nil? && parent.class.to_s == 'Puppet::Pops::Model::CallNamedFunctionExpression' && parent.functor_expr.value == 'include'
+          resource_name = item.value
+          response << type_or_class(resource_name)
+        end
+        # What if it's the name of a resource type or class
+        if !parent.nil? && parent.class.to_s == 'Puppet::Pops::Model::ResourceExpression'
+          resource_name = item.value
+          response << type_or_class(resource_name)
+        end
+
+      when 'Puppet::Pops::Model::ResourceExpression'
+        resource_name = item.type_name.value
+        response << type_or_class(resource_name)
+
+      else
+        raise "Unable to generate Defintion information for object of type #{item.class}"
+      end
+
+      response.compact
+    end
+
+    private
+    def self.type_or_class(resource_name)
+      # Strip the leading double-colons for root resource names
+      resource_name = resource_name.slice(2, resource_name.length - 2) if resource_name.start_with?('::')
+      location = PuppetLanguageServer::PuppetHelper.type_load_info(resource_name)
+      location = PuppetLanguageServer::PuppetHelper.class_load_info(resource_name) if location.nil?
+      unless location.nil?
+        return LanguageServer::Location.create({
+          'uri' => 'file:///' + location['source'],
+          'fromline' => location['line'],
+          'fromchar' => 0,
+          'toline' => location['line'],
+          'tochar' => 1024,
+        })
+      end
+      nil
+    end
+
+    def self.function_name(func_name)
+      location = PuppetLanguageServer::PuppetHelper.function_load_info(func_name)
+      unless location.nil?
+        return LanguageServer::Location.create({
+          'uri' => 'file:///' + location['source'],
+          'fromline' => location['line'],
+          'fromchar' => 0,
+          'toline' => location['line'],
+          'tochar' => 1024,
+        })
+      end
+      nil
+    end
+
+  end
+end

--- a/server/lib/puppet-languageserver/definition_provider.rb
+++ b/server/lib/puppet-languageserver/definition_provider.rb
@@ -14,6 +14,21 @@ module PuppetLanguageServer
         func_name = item.functor_expr.value
         response << function_name(resource_name)
 
+      when 'Puppet::Pops::Model::LiteralString'
+        # LiteralString could be anything.  Context is the key here
+        parent = path.last
+
+        # What if it's a resource name.  Then the Literal String must be the same as the Resource Title
+        # e.g.
+        # class { 'testclass':    <--- testclass would be the LiteralString inside a ResourceBody
+        # }
+        if !parent.nil? &&
+          parent.class.to_s == 'Puppet::Pops::Model::ResourceBody' &&
+          parent.title.value == item.value
+            resource_name = item.value
+            response << type_or_class(resource_name)
+        end
+
       when 'Puppet::Pops::Model::QualifiedName'
         # Qualified names could be anything.  Context is the key here
         parent = path.last

--- a/server/lib/puppet-languageserver/message_router.rb
+++ b/server/lib/puppet-languageserver/message_router.rb
@@ -184,6 +184,20 @@ TEXT
           PuppetLanguageServer.log_message(:error, "(textDocument/hover) #{exception}")
           request.reply_result(LanguageServer::Hover.create_nil_response)
         end
+
+      when 'textDocument/definition'
+        file_uri = request.params['textDocument']['uri']
+        line_num = request.params['position']['line']
+        char_num = request.params['position']['character']
+        content = documents.document(file_uri)
+        begin
+          #raise "Not Implemented"
+          request.reply_result(PuppetLanguageServer::DefinitionProvider.find_definition(content, line_num, char_num))
+        rescue StandardError => exception
+          PuppetLanguageServer.log_message(:error, "(textDocument/definition) #{exception}")
+          request.reply_result($null)
+        end
+
       else
         PuppetLanguageServer.log_message(:error, "Unknown RPC method #{request.rpc_method}")
       end

--- a/server/lib/puppet-languageserver/message_router.rb
+++ b/server/lib/puppet-languageserver/message_router.rb
@@ -101,7 +101,8 @@ TEXT
                                                                   'facterVersion'   => Facter.version,
                                                                   'factsLoaded'     => PuppetLanguageServer::FacterHelper.facts_loaded?,
                                                                   'functionsLoaded' => PuppetLanguageServer::PuppetHelper.functions_loaded?,
-                                                                  'typesLoaded'     => PuppetLanguageServer::PuppetHelper.types_loaded?))
+                                                                  'typesLoaded'     => PuppetLanguageServer::PuppetHelper.types_loaded?,
+                                                                  'classesLoaded'   => PuppetLanguageServer::PuppetHelper.classes_loaded?))
 
       when 'puppet/getResource'
         type_name = request.params['typename']

--- a/server/lib/puppet-languageserver/puppet_helper.rb
+++ b/server/lib/puppet-languageserver/puppet_helper.rb
@@ -1,15 +1,20 @@
 require 'puppet/indirector/face'
-
+require 'pathname'
 module PuppetLanguageServer
   module PuppetHelper
     # Reference - https://github.com/puppetlabs/puppet/blob/master/lib/puppet/reference/type.rb
 
     @ops_lock_types = Mutex.new
     @ops_lock_funcs = Mutex.new
+    @ops_lock_classes = Mutex.new
     @types_hash = nil
     @function_module = nil
     @types_loaded = nil
     @functions_loaded = nil
+    @classes_loaded = nil
+    @class_load_info = {}
+    @function_load_info = {}
+    @type_load_info = {}
 
     def self.reset
       @ops_lock_types.synchronize do
@@ -114,6 +119,49 @@ module PuppetLanguageServer
       result
     end
 
+    # Classes and Defined Types
+    def self.classes_loaded?
+      @classes_loaded.nil? ? false : @classes_loaded
+    end
+
+    def self.load_classes
+      @ops_lock_classes.synchronize do
+        _load_classes if @classes_loaded.nil?
+      end
+    end
+
+    def self.load_classes_async
+      Thread.new do
+        load_classes
+      end
+    end
+
+    # Loading information
+    def self.add_function_load_info(name, options)
+      @function_load_info[name.to_s] = options
+    end
+
+    def self.function_load_info(name)
+      options = @function_load_info[name.to_s]
+      options.nil? ? nil : options.dup
+    end
+
+    def self.add_type_load_info(name, options)
+      @type_load_info[name.to_s] = options
+    end
+
+    def self.type_load_info(name)
+      options = @type_load_info[name.to_s]
+      options.nil? ? nil : options.dup
+    end
+
+    def self.class_load_info(name)
+      # This is the only entrypoint to class loading
+      load_classes
+      options = @class_load_info[name.to_s]
+      options.nil? ? nil : options.dup
+    end
+
     # DO NOT ops_lock on any of these methods
     # deadlocks will ensue!
     def self._reset
@@ -121,6 +169,10 @@ module PuppetLanguageServer
       @function_module = nil
       @types_loaded = nil
       @functions_loaded = nil
+      @classes_loaded = nil
+      @function_load_info = {}
+      @type_load_info = {}
+      @class_load_info = {}
     end
     private_class_method :_reset
 
@@ -133,6 +185,126 @@ module PuppetLanguageServer
       end
     end
     private_class_method :prune_resource_parameters
+
+    # Class and Defined Type loading
+    def self._load_classes
+      @classes_loaded = false
+      module_path_list = []
+      # Add the base modulepath
+      module_path_list.concat(Puppet::Node::Environment.split_path(Puppet.settings[:basemodulepath]))
+      # Add the modulepath
+      module_path_list.concat(Puppet::Node::Environment.split_path(Puppet.settings[:modulepath]))
+
+      # Add the environment specified in puppet conf - This can be overridden by the master but there's no way to know.
+      unless Puppet.settings[:environmentpath].nil?
+        module_path_list << File.join(Puppet.settings[:environmentpath], Puppet.settings[:environment], 'modules') unless Puppet.settings[:environment].nil?
+
+        module_path_list.concat(Pathname.new(Puppet.settings[:environmentpath])
+                                  .children
+                                  .select { |c| c.directory? }
+                                  .collect { |c| File.join(c, 'modules') }
+                               )
+      end
+      module_path_list.uniq!
+      PuppetLanguageServer.log_message(:debug, "[PuppetHelper::_load_classes] Loading classes from #{module_path_list}")
+
+      # Find all of the manifest paths for all of the modules...
+      manifest_path_list = []
+      module_path_list.each do |module_path|
+        next unless File.exists?(module_path)
+        Pathname.new(module_path)
+          .children
+          .select { |c| c.directory? }
+          .each do |module_filepath|
+            manifest_path = File.join(module_filepath,'manifests')
+            manifest_path_list << manifest_path if File.exists?(manifest_path)
+          end
+      end
+
+      # Find and parse all manifests in the manifest paths
+      @class_load_info = {}
+      manifest_path_list.each do |manifest_path|
+        Dir.glob("#{manifest_path}/**/*.pp").each do |manifest_file|
+          classes = load_classes_from_manifest(manifest_file)
+          next if classes.nil?
+          classes.each do |key, data|
+            @class_load_info[key] = data unless @class_load_info.has_key?(name)
+          end
+        end
+      end
+      @classes_loaded = true
+
+      PuppetLanguageServer.log_message(:debug, "[PuppetHelper::_load_classes] Finished loading #{@class_load_info.count} classes")
+      nil
+    end
+    private_class_method :_load_classes
+
+    def self.load_classes_from_manifest(manifest_file)
+      file_content = File.open(manifest_file, "r:UTF-8") { |f| f.read }
+
+      parser = Puppet::Pops::Parser::Parser.new
+      result = nil
+      begin
+        result = parser.parse_string(file_content, '')
+      rescue Puppet::ParseErrorWithIssue => _exception
+        # Any parsing errors means we can't inspect the document
+        return nil
+      end
+
+      class_info = {}
+      # Enumerate the entire AST looking for classes and defined types
+      # TODO - Need to learn how to read the help/docs for hover support
+      if result.model.respond_to? :eAllContents
+        # TODO Puppet 4 language stuff
+        result.model.eAllContents.select do |item|
+          case item.class.to_s
+          when 'Puppet::Pops::Model::HostClassDefinition'
+            class_info[item.name] = {
+              'name' => item.name,
+              'type' => 'class',
+              'parameters' => item.parameters,
+              'source' => manifest_file,
+              'line' => result.locator.line_for_offset(item.offset) - 1,
+              'char' => result.locator.offset_on_line(item.offset)
+            }
+          when 'Puppet::Pops::Model::ResourceTypeDefinition'
+            class_info[item.name] = {
+              'name' => item.name,
+              'type' => 'typedefinition',
+              'parameters' => item.parameters,
+              'source' => manifest_file,
+              'line' => result.locator.line_for_offset(item.offset) - 1,
+              'char' => result.locator.offset_on_line(item.offset)
+            }
+          end
+        end
+      else
+        result.model._pcore_all_contents([]) do |item|
+          case item.class.to_s
+          when 'Puppet::Pops::Model::HostClassDefinition'
+            class_info[item.name] = {
+              'name' => item.name,
+              'type' => 'class',
+              'parameters' => item.parameters,
+              'source' => manifest_file,
+              'line' => item.line,
+              'char' => item.pos
+            }
+          when 'Puppet::Pops::Model::ResourceTypeDefinition'
+            class_info[item.name] = {
+              'name' => item.name,
+              'type' => 'typedefinition',
+              'parameters' => item.parameters,
+              'source' => manifest_file,
+              'line' => item.line,
+              'char' => item.pos
+            }
+          end
+        end
+      end
+
+      class_info
+    end
 
     def self._load_types
       @types_loaded = false

--- a/server/lib/puppet-languageserver/puppet_monkey_patches.rb
+++ b/server/lib/puppet-languageserver/puppet_monkey_patches.rb
@@ -1,0 +1,38 @@
+
+
+# Monkey Patch 3.x functions so where know where they were loaded from
+require 'puppet/parser/functions'
+module Puppet::Parser::Functions
+  class << self
+    alias_method :original_newfunction, :newfunction
+    def newfunction(name, options = {}, &block)
+      # See if we've hooked elsewhere. This can happen while in debuggers (pry). If we're not in the previous caller
+      # stack then just use the last caller
+      monkey_index = Kernel.caller_locations.find_index{ |loc| loc.path.match(/puppet_monkey_patches\.rb/) }
+      monkey_index = -1 if monkey_index.nil?
+      caller = Kernel.caller_locations[monkey_index + 1]
+      PuppetLanguageServer::PuppetHelper.add_function_load_info(name, {
+        'source' => caller.absolute_path,
+        'line'   => caller.lineno - 1, # Convert to a zero based line number system
+      })
+
+      original_newfunction(name, options, &block)
+    end
+  end
+end
+
+
+require 'puppet/metatype/manager'
+module Puppet::MetaType::Manager
+  alias_method :original_newtype, :newtype
+  def newtype(name, options = {}, &block)
+    if block_given? && !block.source_location.nil?
+      PuppetLanguageServer::PuppetHelper.add_type_load_info(name, {
+        'source' => block.source_location[0],
+        'line'   => block.source_location[1] - 1, # Convert to a zero based line number system
+      })
+    end
+
+    original_newtype(name, options, &block)
+  end
+end

--- a/server/lib/puppet-languageserver/server_capabilities.rb
+++ b/server/lib/puppet-languageserver/server_capabilities.rb
@@ -9,7 +9,8 @@ module PuppetLanguageServer
         'completionProvider' => {
           'resolveProvider' => true,
           'triggerCharacters' => ['>', '$', '[', '=']
-        }
+        },
+        'definitionProvider' => true,
       }
     end
   end

--- a/server/spec/languageserver/fixtures/environments/test-fixtures/modules/definedtypes/manifests/deftypeone.pp
+++ b/server/spec/languageserver/fixtures/environments/test-fixtures/modules/definedtypes/manifests/deftypeone.pp
@@ -1,0 +1,4 @@
+define deftypeone(
+  $ensure       = 'UNSET',
+) {
+}

--- a/server/spec/languageserver/fixtures/environments/test-fixtures/modules/definedtypes/metadata.json
+++ b/server/spec/languageserver/fixtures/environments/test-fixtures/modules/definedtypes/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "testfixture-definedtypes",
+  "version": "0.1.0",
+  "author": "testfixture",
+  "summary": "Test fixture with defined types",
+  "license": "Apache-2.0",
+  "source": "http://localhost",
+  "dependencies": []
+}

--- a/server/spec/languageserver/fixtures/environments/test-fixtures/modules/testclasses/manifests/init.pp
+++ b/server/spec/languageserver/fixtures/environments/test-fixtures/modules/testclasses/manifests/init.pp
@@ -1,0 +1,3 @@
+class testclasses () {
+  $param1 = 'value2'
+}

--- a/server/spec/languageserver/fixtures/environments/test-fixtures/modules/testclasses/manifests/nestedclass.pp
+++ b/server/spec/languageserver/fixtures/environments/test-fixtures/modules/testclasses/manifests/nestedclass.pp
@@ -1,0 +1,3 @@
+class testclasses::nestedclass () {
+  $param1 = 'value2'
+}

--- a/server/spec/languageserver/fixtures/environments/test-fixtures/modules/testclasses/manifests/puppetclassone.pp
+++ b/server/spec/languageserver/fixtures/environments/test-fixtures/modules/testclasses/manifests/puppetclassone.pp
@@ -1,0 +1,3 @@
+class puppetclassone () {
+  $param1 = 'value1'
+}

--- a/server/spec/languageserver/fixtures/environments/test-fixtures/modules/testclasses/metadata.json
+++ b/server/spec/languageserver/fixtures/environments/test-fixtures/modules/testclasses/metadata.json
@@ -1,0 +1,9 @@
+{
+  "name": "testfixture-testclasses",
+  "version": "0.1.0",
+  "author": "testfixture",
+  "summary": "Test fixture with puppet classes",
+  "license": "Apache-2.0",
+  "source": "http://localhost",
+  "dependencies": []
+}

--- a/server/spec/languageserver/integration/puppet-languageserver/definition_provider_spec.rb
+++ b/server/spec/languageserver/integration/puppet-languageserver/definition_provider_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper'
+
+RSpec.shared_examples "a single definition result" do |filename_regex|
+  it "should return a single definition result which matches #{filename_regex.to_s}" do
+    result = subject.find_definition(content, line_num, char_num)
+
+    expect(result).to be_a(Array)
+    expect(result.count).to eq(1)
+    expect(result[0]['uri']).to match(filename_regex)
+    expect(result[0]['range']['start']['line']).to_not be_nil
+    expect(result[0]['range']['start']['character']).to_not be_nil
+    expect(result[0]['range']['end']['line']).to_not be_nil
+    expect(result[0]['range']['end']['character']).to_not be_nil
+  end
+end
+
+describe 'definition_provider' do
+  let(:subject) { PuppetLanguageServer::DefinitionProvider }
+
+  describe '#find_defintion' do
+    before(:all) do
+      # Ensure the functions are loaded so that defintion information is available
+      PuppetLanguageServer::PuppetHelper.load_functions unless PuppetLanguageServer::PuppetHelper.functions_loaded?
+
+      # Ensure the types are loaded so that defintion information is available
+      PuppetLanguageServer::PuppetHelper.load_types unless PuppetLanguageServer::PuppetHelper.types_loaded?
+
+      # Ensure the classes are loaded so that defintion information is available
+      PuppetLanguageServer::PuppetHelper.load_classes unless PuppetLanguageServer::PuppetHelper.classes_loaded?
+    end
+
+    context 'When cursor is on a function name' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  alert('This is an alert message')
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 5 }
+
+      it_should_behave_like "a single definition result", /functions\.rb/
+    end
+
+    context 'When cursor is on a custom puppet type' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  user { 'foo':
+    ensure => 'present',
+    name   => 'name',
+  }
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 5 }
+
+      it_should_behave_like "a single definition result", /user\.rb/
+    end
+
+    context 'When cursor is on a defined type' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  deftypeone { 'foo':
+    ensure => 'present',
+  }
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 5 }
+
+      it_should_behave_like "a single definition result", /deftypeone\.pp/
+    end
+
+    context 'When cursor is on a puppet class' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  puppetclassone { 'foo':
+    ensure => 'present',
+  }
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 5 }
+
+      it_should_behave_like "a single definition result", /puppetclassone\.pp/
+    end
+
+    context 'When cursor is on a classname for an include statement' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  include puppetclassone
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 14 }
+
+      it_should_behave_like "a single definition result", /puppetclassone\.pp/
+    end
+
+    context 'When cursor is on a fully qualified classname for an include statement' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  include testclasses::nestedclass
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 14 }
+
+      it_should_behave_like "a single definition result", /nestedclass\.pp/
+    end
+
+    context 'When cursor is on a root classname for an include statement' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  include ::puppetclassone
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 14 }
+
+      it_should_behave_like "a single definition result", /puppetclassone\.pp/
+    end
+
+    context 'When cursor is on a function name for an include statement' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  include puppetclassone
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 5 }
+
+      it_should_behave_like "a single definition result", /include\.rb/
+    end
+
+  end
+end

--- a/server/spec/languageserver/integration/puppet-languageserver/definition_provider_spec.rb
+++ b/server/spec/languageserver/integration/puppet-languageserver/definition_provider_spec.rb
@@ -58,6 +58,51 @@ EOT
       it_should_behave_like "a single definition result", /user\.rb/
     end
 
+    context 'When cursor is on a puppet class' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  class { 'testclasses':
+    ensure => 'present',
+  }
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 13 }
+
+      it_should_behave_like "a single definition result", /init\.pp/
+    end
+
+    context 'When cursor is on a root puppet class' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  class { '::testclasses':
+    ensure => 'present',
+  }
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 13 }
+
+      it_should_behave_like "a single definition result", /init\.pp/
+    end
+
+    context 'When cursor is on a fully qualified puppet class' do
+      let(:content) { <<-EOT
+class Test::NoParams {
+  class { 'testclasses::nestedclass':
+    ensure => 'present',
+  }
+}
+EOT
+      }
+      let(:line_num) { 1 }
+      let(:char_num) { 13 }
+
+      it_should_behave_like "a single definition result", /nestedclass\.pp/
+    end
+
     context 'When cursor is on a defined type' do
       let(:content) { <<-EOT
 class Test::NoParams {


### PR DESCRIPTION
Previously the Language Server did not respond to find definition requests from
the client.  This commit
* Adds a request handler for the textDocument/definition request
* A definition provider class which will extract the definition
* Monkey patch Type and Function loading so the language server can determine
  where types and functions came from
* Added definition provider as a language server capability

This commit adds parsing of puppet manifests for classes and defined types for
manifests that exist in the module path.
* The classes are loading async if preload is configured
* Will respond to definition requests if a type with the same name could not be
  found

---

This commit adds class loading the client UI so instead of steps 1 to 3, there
are now 4 steps (Functions, Classes, Types and Facts).

---

reviously definition detection would fail on resource bodies as the text comes
in as a LiteralString e.g.

class { 'testclass':    <--- testclass would be the LiteralString inside
} 							 a ResourceBody

This commit updates the definition provider to detect these instances and return
a defintion location.  This commit also adds tests for this scenario.

---

Note this does not support finding definitions for things in the current workspace, only in the modulepath or default puppet locations.