### PR TITLE
(maint) Fix logger in PDK New Task

### DIFF
--- a/client/src/commands/pdk/pdkNewTaskCommand.ts
+++ b/client/src/commands/pdk/pdkNewTaskCommand.ts
@@ -3,15 +3,15 @@
 import * as vscode from 'vscode';
 import * as cp from 'child_process';
 import ChildProcess = cp.ChildProcess;
-import { Logger } from '../../logging';
+import { ILogger } from '../../logging';
 import { reporter } from '../../telemetry/telemetry';
 import * as messages from '../../messages';
 
 export class pdkNewTaskCommand {
-  private logger: Logger = undefined;
+  private logger: ILogger = undefined;
   private terminal: vscode.Terminal = undefined;
 
-  constructor(logger: Logger, terminal: vscode.Terminal) {
+  constructor(logger: ILogger, terminal: vscode.Terminal) {
     this.logger = logger;
     this.terminal = terminal;
   }


### PR DESCRIPTION
Previously the Logging classes were changed to an interface.  This commit fixes
a missed conversion which was causing TypeScript errors.