### PR TITLE
(maint) Use noop by default and fix readme typo

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -104,7 +104,7 @@ To use any of the above commands, open the command palette and start typing a co
 
 **Note - This is an experimental feature**
 
-The Puppet extension is able to debug the compilation of a Puppet manifest, much like a Go, PowerShell, C# etc.  The debugger supports:
+The Puppet extension is able to debug the compilation of a Puppet manifest, much like the Go, PowerShell, and C# languages.  The debugger supports:
 
 * Line breakpoints but not conditions on those breakpoints
 * Function breakpoints
@@ -116,11 +116,13 @@ The Puppet extension is able to debug the compilation of a Puppet manifest, much
 
 You may be presented with a Launch Configuration on first use.  Please see the [VSCode Debugging link](https://code.visualstudio.com/docs/editor/debugging) for instructions on how to set this up.
 
+The debugging features in the extension are based on the excellent ideas in [puppet-debugger](https://www.puppet-debugger.com/) by [Corey Osman](https://github.com/nwops).
+
 Settings:
 
 `manifest` - The manifest to apply.  By default this is the currently open file in the editor
 
-`noop` - Whether the `puppet apply` sets No Operation (Noop) mode.  By default, this is set to false.  This means when runing the debugger it can make changes to your system
+`noop` - Whether the `puppet apply` sets No Operation (Noop) mode.  By default, this is set to true.  This means when running the debugger it will not make changes to your system. The [documentation about the puppet agent](https://puppet.com/docs/puppet/5.3/man/apply.html#OPTIONS) has more information about `puppet apply` and and the `noop` option.
 
 `args` - Additional arguements to pass to `puppet apply`, for example `['--debug']` will output debug information
 

--- a/client/package.json
+++ b/client/package.json
@@ -353,8 +353,8 @@
               },
               "noop": {
                 "type": "boolean",
-                "description": "Optional: Whether the the Puppet run is in NoOp mode. Default is false.",
-                "default": false
+                "description": "Optional: Whether the the Puppet run is in NoOp mode. Default is true.",
+                "default": true
               },
               "args": {
                 "type": "array",


### PR DESCRIPTION
Previously the debug server would default to applying changes to the system
instead of being opt-in.  This commit changes the deafault value of noop to true
to make it safe by default.  This commit also fixes typos in the README and
credits Corey Osman with ideas behind the debug server.
