### PR TITLE
(maint) Fix typo in class loader for puppet-languageserver

### DIFF
--- a/server/lib/puppet-languageserver.rb
+++ b/server/lib/puppet-languageserver.rb
@@ -10,7 +10,7 @@ begin
     begin
       require "puppet-languageserver/#{lib}"
     rescue LoadError
-      require File.expand_path(File.join(File.dirname(__FILE__), 'puppet-languageserver', 'lib'))
+      require File.expand_path(File.join(File.dirname(__FILE__), 'puppet-languageserver', lib))
     end
   end
 


### PR DESCRIPTION
Previously the language server would fail to load the required language server
libraries as there was a typo in the require statement.  This commit removes the
quotes around lib as it is not a string, but a string variable.