### PR TITLE
(GH-196) Add ruby testing to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,103 @@
+---
 sudo: false
 language: cpp
 
 os:
   - linux
+# Do we actually need to run this on OSX?
+# OSX is REALLY slow to test
+#  - osx
 
-environment:
-  VSCODE_BUILD_VERBOSE: true
+matrix:
+  fast_finish: true
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.9
-      - g++-4.9
-      - gcc-4.9-multilib
-      - g++-4.9-multilib
-      - zip
-      - libgtk2.0-0
-      - libx11-dev
-      - libxkbfile-dev
-      - libsecret-1-dev
+env:
+  global:
+    VSCODE_BUILD_VERBOSE: true
+  matrix:
+    # Language Server testing
+    # LTS Agent
+    - PUPPET_GEM_VERSION="~> 4.7.0"
+      RUBY_VER=2.1.9
+      RAKE_TASK=test_languageserver
 
-before_install:
-  - git clone --depth 1 https://github.com/creationix/nvm.git ./.nvm
-  - source ./.nvm/nvm.sh
-  - nvm install 7.4.0
-  - nvm use 7.4.0
-  - npm install -g gulp
-  - if [ $TRAVIS_OS_NAME == "linux" ]; then
-      export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-      sh -e /etc/init.d/xvfb start;
-      sleep 3;
-    fi
+    # Latest 4.x branch
+    - PUPPET_GEM_VERSION="~> 4.0"
+      RUBY_VER=2.1.9
+      RAKE_TASK=test_languageserver
+    # Latest Puppet
+    - PUPPET_GEM_VERSION="~> 5.0"
+      RUBY_VER=2.4.1
+      RAKE_TASK=test_languageserver
+    # Specific Puppet version testing
+    - PUPPET_GEM_VERSION="5.1.0"
+      RUBY_VER=2.4.1
+      RAKE_TASK=test_languageserver
+
+    # Debug Server testing
+    # LTS Agent
+    - PUPPET_GEM_VERSION="~> 4.7.0"
+      RUBY_VER=2.1.9
+      RAKE_TASK=test_debugserver
+    # Latest 4.x branch
+    - PUPPET_GEM_VERSION="~> 4.0"
+      RUBY_VER=2.1.9
+      RAKE_TASK=test_debugserver
+    # Latest Puppet
+    - PUPPET_GEM_VERSION="~> 5.0"
+      RUBY_VER=2.4.1
+      RAKE_TASK=test_debugserver
+
+    # Ruby style
+    - PUPPET_GEM_VERSION="~> 4.0"
+      RUBY_VER=2.4.1
+      RAKE_TASK=rubocop
+
+    # Extension testing
+
+    # Package it up to a VSIX
+    - nodejs_version: "7.4.0"
+      nodejs_arch: "x64"
+      VSCE_TASK: package
+
+before_install: true
 
 install:
-  - cd client
-  - npm install
-  - npm run vscode:prepublish
+  - "export BUILD_VERSION=0.7.0-travis.$TRAVIS_BUILD_NUMBER"
+  - if [ "$RUBY_VER" != "" ]; then
+      cd server;
+      rvm install $RUBY_VER;
+      rvm use $RUBY_VER;
+      ruby -v;
+      gem -v;
+      bundle -v;
+      bundle install;
+      cat Gemfile.lock;
+    fi
+  - if [ "$nodejs_version" != "" ]; then
+      cd client;
+      git clone --depth 1 https://github.com/creationix/nvm.git ./.nvm;
+      source ./.nvm/nvm.sh;
+      nvm install $nodejs_version;
+      nvm use $nodejs_version;
+      npm install -g gulp;
+      if [ $TRAVIS_OS_NAME == "linux" ]; then
+        export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
+        sh -e /etc/init.d/xvfb start;
+        sleep 3;
+      fi;
+      node --version;
+      npm install -g npm@4 --silent;
+      npm --version;
+      npm install -g vsce --silent;
+      npm install --silent;
+      node node_modules/gulp/bin/gulp.js bump --version $BUILD_VERSION;
+    fi
 
 script:
-  - npm test --silent
-  - gulp build
+  - if [ "$RAKE_TASK" != "" ]; then
+      bundle exec rake $RAKE_TASK;
+    fi
+  - if [ "$VSCE_TASK" != "" ]; then
+      vsce $VSCE_TASK;
+    fi

--- a/server/Gemfile
+++ b/server/Gemfile
@@ -19,6 +19,11 @@ group :development do
     gem 'puppet',                            :require => false
   end
 
+  case RUBY_PLATFORM
+  when /darwin/
+    gem 'CFPropertyList'
+  end
+
   gem "win32-dir", "<= 0.4.9",      :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
   gem "win32-eventlog", "<= 0.6.5", :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
   gem "win32-process", "<= 0.7.5",  :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]

--- a/server/spec/debugserver/integration/puppet-debugserver/end_to_end_spec.rb
+++ b/server/spec/debugserver/integration/puppet-debugserver/end_to_end_spec.rb
@@ -10,7 +10,7 @@ describe 'End to End Testing' do
 
     # Start the debug server
     debug_entrypoint = File.join($root_dir,'puppet-debugserver')
-    @debug_stdin, @debug_stdout, @debug_stderr, wait_thr = Open3.popen3('ruby.exe',debug_entrypoint,
+    @debug_stdin, @debug_stdout, @debug_stderr, wait_thr = Open3.popen3('ruby',debug_entrypoint,
                                                                         '--timeout=10',
                                                                         "--port=#{@debug_port}",
                                                                         "--ip=#{@debug_host}")


### PR DESCRIPTION
The CFProperty gem is vendored in Puppet Agent however for the language server
it needs to be added to the development section for developers on Mac
platforms.

---

The debug server integration tests reference ruby.exe however this does not
work on linux.  This commit changes the executable used to just ruby.

---

This commit updates travis configuration to test the language server, debug
server and building the VSIX file.  Currently it only functions on the linux
containers however it can be configurated to run on the OSX builders.