### PR TITLE
(maint) Make rubocop failures fatal

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,11 +50,6 @@ environment:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    # Ruby style
-    - PUPPET_GEM_VERSION: "~> 4.0"
-      RUBY_VER: 23-x64
-      RAKE_TASK: rubocop
 
 install:
 - ps: |


### PR DESCRIPTION
Previously Appveyor would tolerate rubocop failures.  However this hasn't been
stopping badly formatted code making it into master.  This commit changes
Appveyor to consider rubocop failures as failures and to fail the build if
encountered.
