### PR TITLE
Add debug server integration tests

### DIFF
--- a/server/lib/debugserver/debug_protocol.rb
+++ b/server/lib/debugserver/debug_protocol.rb
@@ -334,6 +334,15 @@ module PuppetDebugServer
       end
     end
 
+    # /** Response to 'configurationDone' request. This is just an acknowledgement, so no body field is required. */
+    # export interface ConfigurationDoneResponse extends Response {
+    # }
+    module ConfigurationDoneResponse
+      def self.create_from_request(options, request = nil)
+        Response.create_from_request(options, request)
+      end
+    end
+
     # /** Launch request; value of command field is 'launch'. */
     # export interface LaunchRequest extends Request {
     # 	// command: 'launch';

--- a/server/lib/puppet-debugserver/debug_hook_handlers.rb
+++ b/server/lib/puppet-debugserver/debug_hook_handlers.rb
@@ -21,6 +21,7 @@ module PuppetDebugServer
     end
 
     def self.hook_before_pops_evaluate(args)
+      return if PuppetDebugServer::PuppetDebugSession.session_paused?
       @session_pops_eval_depth += 1
       target = args[1]
       # Ignore this if there is no positioning information available
@@ -101,7 +102,8 @@ module PuppetDebugServer
     end
 
     def self.hook_after_pops_evaluate(args)
-      @session_pops_eval_depth -= @session_pops_eval_depth
+      return if PuppetDebugServer::PuppetDebugSession.session_paused?
+      @session_pops_eval_depth -= 1
       target = args[1]
       return unless target.is_a?(Puppet::Pops::Model::Positioned)
     end

--- a/server/lib/puppet-debugserver/debug_hook_handlers.rb
+++ b/server/lib/puppet-debugserver/debug_hook_handlers.rb
@@ -158,6 +158,11 @@ module PuppetDebugServer
       end
 
       break_description = break_display_text if break_description.empty?
+      stack_trace = Puppet::Pops::PuppetStack.stacktrace
+      # Due to https://github.com/puppetlabs/puppet/commit/0f96dd918b6184261bc2219e5e68e246ffbeac10
+      # Prior to Puppet 4.8.0, stacktrace is in reverse order
+      stack_trace.reverse! if Gem::Version.new(Puppet.version) < Gem::Version.new('4.8.0')
+
       PuppetDebugServer::PuppetDebugSession.raise_and_wait_stopped_event(
         reason,
         break_display_text,
@@ -165,7 +170,7 @@ module PuppetDebugServer
         :pops_target       => pops_target_object,
         :scope             => scope_object,
         :pops_depth_level  => pops_depth_level,
-        :puppet_stacktrace => Puppet::Pops::PuppetStack.stacktrace
+        :puppet_stacktrace => stack_trace
       )
     end
 

--- a/server/lib/puppet-debugserver/json_handler.rb
+++ b/server/lib/puppet-debugserver/json_handler.rb
@@ -76,7 +76,7 @@ module PuppetDebugServer
       # Modify the response
       raise('protocol message type was not set to response') unless response['type'] == 'response'
       response['seq'] = @response_sequence
-      @response_sequence += @response_sequence # Not thread safe possibly. It's ok on MRI ruby, not jruby
+      @response_sequence += 1 # Not thread safe possibly. It's ok on MRI ruby, not jruby
 
       response_json = encode_json(response)
       PuppetDebugServer.log_message(:debug, "--- OUTBOUND\n#{response_json}\n---")

--- a/server/lib/puppet-debugserver/message_router.rb
+++ b/server/lib/puppet-debugserver/message_router.rb
@@ -70,7 +70,7 @@ module PuppetDebugServer
         PuppetDebugServer.log_message(:debug, 'Received configurationDone request.')
         PuppetDebugServer::PuppetDebugSession.client_completed_configuration = true
 
-        response = PuppetDebugServer::Protocol::LaunchResponse.create_from_request(
+        response = PuppetDebugServer::Protocol::ConfigurationDoneResponse.create_from_request(
           {
             'success' => true
           }, request
@@ -135,10 +135,9 @@ module PuppetDebugServer
         PuppetDebugServer.log_message(:debug, 'Received threads request.')
 
         if PuppetDebugServer::PuppetDebugSession.puppet_thread_id.nil?
-          response = PuppetDebugServer::Protocol::ThreadsResponse.create_from_request(
+          response = PuppetDebugServer::Protocol::Response.create_from_request(
             {
-              'success' => false,
-              'threads' => []
+              'success' => false
             }, request
           )
         else

--- a/server/spec/debugserver/fixtures/environments/test-fixtures/manifests/empty.pp
+++ b/server/spec/debugserver/fixtures/environments/test-fixtures/manifests/empty.pp
@@ -1,0 +1,1 @@
+# Empty manifest

--- a/server/spec/debugserver/fixtures/environments/test-fixtures/manifests/fail.pp
+++ b/server/spec/debugserver/fixtures/environments/test-fixtures/manifests/fail.pp
@@ -1,0 +1,3 @@
+# Manifest that fails
+
+fail('This is a failure')

--- a/server/spec/debugserver/fixtures/environments/test-fixtures/manifests/kitchen_sink.pp
+++ b/server/spec/debugserver/fixtures/environments/test-fixtures/manifests/kitchen_sink.pp
@@ -1,0 +1,43 @@
+# Manifest that has everything
+
+# Class: nestedclass  # <--- Breakpoint here
+#
+class nestedclass {
+  # line based breakpoints
+  $nested_variable = 'Yay Puppet!'
+
+  user { 'missing_user':
+    ensure => 'absent'
+  }
+
+  alert('This is an alert message')
+
+  notify {'nested_notify': }
+
+  ["routers", "servers", "workstations"].each |$item| {
+    notify { $item: }
+  }
+}
+
+# Class: democlass
+#
+class democlass {
+  $before_var = 'before'
+
+  include nestedclass
+
+  $after_var = 'after'
+
+  notify {'demo_notify': }
+}
+
+$a_test_string = 'This is a string'
+$a_test_array = [1,2,3]
+
+notice('The start')
+
+include democlass   # <--- Breakpoint here
+
+$another_test_array = split('v1.v2:v3.v4', ':')
+
+notice('The end!')

--- a/server/spec/debugserver/integration/puppet-debugserver/end_to_end_spec.rb
+++ b/server/spec/debugserver/integration/puppet-debugserver/end_to_end_spec.rb
@@ -1,0 +1,439 @@
+require 'spec_debug_helper'
+require 'spec_debug_client'
+require 'open3'
+
+describe 'End to End Testing' do
+  before(:each) {
+    @debug_port = 8082 + Random.rand(1024)
+    @debug_host = 'localhost'
+    @debug_pid = -1
+
+    # Start the debug server
+    debug_entrypoint = File.join($root_dir,'puppet-debugserver')
+    @debug_stdin, @debug_stdout, @debug_stderr, wait_thr = Open3.popen3('ruby.exe',debug_entrypoint,
+                                                                        '--timeout=10',
+                                                                        "--port=#{@debug_port}",
+                                                                        "--ip=#{@debug_host}")
+    @debug_pid = wait_thr.pid
+    # Wait for something to be output from the Debug Server.  This indicates it's alive and ready for a connection
+    result = IO.select([@debug_stdout], [], [], 5)
+    raise('Debug Server did not start up in the required timespan') unless result
+
+    # Now connect to the Debug Server
+    @client = DebugClient.new(@debug_host, @debug_port)
+  }
+
+  after(:each) {
+    @client.close unless @client.closed?
+    Process.kill("KILL", @debug_pid) rescue true
+    @debug_stdin.close
+    @debug_stdout.close
+    @debug_stderr.close
+  }
+
+  context 'Processing an empty manifest with no breakpoints' do
+    let(:manifest_file) { File.join($fixtures_dir, 'environments', 'test-fixtures', 'manifests', 'empty.pp') }
+    let(:noop) { true }
+    let(:args) { [] }
+
+    it 'should process the manifest and exit with 0' do
+      # initialize_request
+      @client.send_data(initialize_request(@client.next_seq_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+
+      # launch_request
+      @client.send_data(launch_request(@client.next_seq_id, manifest_file, noop, args))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+
+      # configuration_done_request
+      @client.send_data(configuration_done_request(@client.next_seq_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+
+      # Wait for the puppet run to complete
+      expect(@client).to receive_event_within_timeout(['terminated', 60])
+
+      # Make sure we received the exited event
+      result = @client.data_from_event_name('exited')
+      expect(result).to_not be nil
+      expect(result['body']['exitCode']).to eq(0)
+    end
+  end
+
+  context 'Processing a manifest that fails compilation' do
+    let(:manifest_file) { File.join($fixtures_dir, 'environments', 'test-fixtures', 'manifests', 'fail.pp') }
+    let(:noop) { true }
+    let(:args) { [] }
+
+    it 'should process the manifest and exit with 1' do
+      # initialize_request
+      @client.send_data(initialize_request(@client.next_seq_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+
+      # launch_request
+      @client.send_data(launch_request(@client.next_seq_id, manifest_file, noop, args))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+
+      # configuration_done_request
+      @client.send_data(configuration_done_request(@client.next_seq_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+
+      # Wait for the exception to raise
+      expect(@client).to receive_event_within_timeout(['stopped', 60])
+      detail = @client.data_from_event_name('stopped')
+      expect(detail['body']['reason']).to eq('exception')
+      expect(detail['body']['text']).to match(/This is a failure/)
+      thread_id = detail['body']['threadId']
+
+      # Ensure it was raised on Line 3
+      # Get the stack trace list
+      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      # As we're only in the root, only two frames should be available.  The error and where it was called from
+      expect(result['success']).to be true
+      expect(result['body']['stackFrames'].count).to eq(2)
+      expect(result['body']['stackFrames'][0]).to include('line' => 3)
+      expect(result['body']['stackFrames'][1]).to include('line' => 3)
+
+      # continue_request
+      @client.send_data(continue_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+
+      # Wait for the puppet run to complete
+      expect(@client).to receive_event_within_timeout(['terminated', 60])
+
+      # Make sure we received the exited event
+      result = @client.data_from_event_name('exited')
+      expect(result).to_not be nil
+      expect(result['body']['exitCode']).to eq(1)
+    end
+  end
+
+  context 'Processing a manifest with all debug features' do
+    let(:manifest_file) { File.join($fixtures_dir, 'environments', 'test-fixtures', 'manifests', 'kitchen_sink.pp') }
+    let(:noop) { true }
+    let(:args) { [] }
+
+    # Things tested
+    # - Line breakpoints
+    # - Function breakpoints
+    # - Continue
+    # - Step In
+    # - Variables list
+    # - Stack Frame list
+    # - Dynamic function breakpoints (Adding while in flight)
+    # - Variable evaluation
+    # - Check that dynamic variable evaluation is available in later break points
+    # - Dynamic line breakpoints (Adding while in flight)
+    # - Step Out
+
+    # From documentation:
+    # A session initialisation should look like;
+    # - adapters sends InitializedEvent (after the InitializeRequest has returned)
+    # - frontend sends zero or more SetBreakpointsRequest
+    # - frontend sends one SetFunctionBreakpointsRequest
+    # - frontend sends a SetExceptionBreakpointsRequest if one or more exceptionBreakpointFilters have been defined (or if supportsConfigurationDoneRequest is not defined or false)
+    # - frontend sends other future configuration requests
+    # - frontend sends one ConfigurationDoneRequest to indicate the end of the configuration
+    # - Launch request can occur during init
+
+    it 'should process the manifest and exit with 0' do
+      # initialize_request
+      @client.send_data(initialize_request(@client.next_seq_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+
+      # set_breakpoints_request
+      @client.send_data(set_breakpoints_request(@client.next_seq_id,
+        {
+          'source'      => {
+            'name' => 'kitchen_sink.pp',
+            'path' => manifest_file
+          },
+          'breakpoints' => [
+            { 'line' => 3  }, # This breakpoint is on a comment line and should not be verified
+            { 'line' => 39 }
+          ]
+        }
+      ))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      # Ensure the breakpoint response is as expected
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      expect(result['success']).to eq('true')
+      # Breakpoint on a comment line
+      expect(result['body']['breakpoints'][0]['verified']).to be false
+      expect(result['body']['breakpoints'][0]['message']).to match(/Line does not exist or is blank/)
+      # Breakpoint at root of manifest
+      expect(result['body']['breakpoints'][1]['verified']).to be true
+
+      # set_function_breakpoints_request
+      @client.send_data(set_function_breakpoints_request(@client.next_seq_id,
+        {
+          'breakpoints' => [
+            { 'name' => 'alert' }
+          ]
+        }
+      ))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      # Ensure the breakpoint response is as expected
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      expect(result['body']['breakpoints'][0]['verified']).to be true
+
+      # launch_request
+      @client.send_data(launch_request(@client.next_seq_id, manifest_file, noop, args))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+
+      # configuration_done_request
+      @client.send_data(configuration_done_request(@client.next_seq_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+
+      # -----
+      # This breakpoint is in the root of the manifest and has two variables defined
+      # a_test_string and a_test_array
+      # Line 39
+      # -----
+
+      # Wait for the breakpoint to be hit
+      expect(@client).to receive_event_within_timeout(['stopped', 60])
+      result = @client.data_from_event_name('stopped')
+      expect(result['body']['reason']).to eq('breakpoint')
+      thread_id = result['body']['threadId']
+
+      # Get the stack trace list
+      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      # As we're only in the root, only one frame should be available
+      expect(result['success']).to be true
+      expect(result['body']['stackFrames'].count).to eq(1)
+      expect(result['body']['stackFrames'][0]).to include('line' => 39)
+
+      # Get the available scopes list
+      @client.send_data(scopes_request(@client.next_seq_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      expect(result['success']).to be true
+      # As we're only in the root, only one scope should be available
+      expect(result['body']['scopes'].count).to eq(1)
+      variables_reference = result['body']['scopes'][0]['variablesReference']
+
+      # Get the variables list
+      @client.send_data(variables_request(@client.next_seq_id, variables_reference))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+
+      # Ensure the $a_test_string variable is set correctly
+      expect(result['body']['variables'].find { |item| item['name'] == 'a_test_string'}).to include('value' => 'This is a string')
+      # Ensure the core fact, in the global scope, exists 'operatingsystem'
+      expect(result['body']['variables'].find { |item| item['name'] == 'operatingsystem'}).to_not be nil
+      # Ensure the $a_test_array variable exists
+      obj = result['body']['variables'].find { |item| item['name'] == 'a_test_array'}
+      expect(obj).to_not be nil
+      # Get more details about the $a_test_array variable
+      @client.send_data(variables_request(@client.next_seq_id, obj['variablesReference']))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      # Ensure the $a_test_array variable contents is correct
+      expect(result['body']['variables'][0]).to include('name' => '0', 'value' => '1')
+      expect(result['body']['variables'][1]).to include('name' => '1', 'value' => '2')
+      expect(result['body']['variables'][2]).to include('name' => '2', 'value' => '3')
+
+      # -----
+      # Now to Step In twice and we should be inside the class called democlass
+      # -----
+      @client.clear_messages!
+      @client.send_data(stepin_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_event_within_timeout(['stopped', 60])
+
+      @client.clear_messages!
+      @client.send_data(stepin_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_event_within_timeout(['stopped', 60])
+
+      # Get the stack trace list
+      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      # The stack should be two levels deep (root -> democlass)
+      expect(result['success']).to be true
+      expect(result['body']['stackFrames'].count).to eq(2)
+      expect(result['body']['stackFrames'][0]).to include('line' => 24)
+      expect(result['body']['stackFrames'][1]).to include('line' => 39)
+
+      # -----
+      # Now we wait to hit the alert function which is in the nestedclass class
+      # Line 13
+      # -----
+
+      # Wait for the breakpoint to be hit
+      @client.clear_messages!
+      @client.send_data(continue_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_event_within_timeout(['stopped', 60])
+      result = @client.data_from_event_name('stopped')
+      expect(result['body']['reason']).to eq('function breakpoint')
+      expect(result['body']['description']).to eq('alert')
+      thread_id = result['body']['threadId']
+
+      # Get the stack trace list
+      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      # The stack should be three levels deep (root -> democlass -> nestedclass)
+      expect(result['success']).to be true
+      expect(result['body']['stackFrames'].count).to eq(3)
+      expect(result['body']['stackFrames'][0]).to include('line' => 13, 'column' => 3, 'endColumn' => 36)
+      expect(result['body']['stackFrames'][1]).to include('line' => 27)
+      expect(result['body']['stackFrames'][2]).to include('line' => 39)
+
+      # Evaluate that $before_var exists but $after_var does not.  Also add $mid_var to check later
+      # - Check $democlass::before_var
+      @client.send_data(evaluate_request(@client.next_seq_id, '$democlass::before_var', 0))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      expect(result['body']['result']).to eq('before')
+      # - Check $democlass::after_var
+      @client.send_data(evaluate_request(@client.next_seq_id, '$democlass::after_var', 0))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      expect(result['body']['result']).to eq('')
+      # - Create $mid_var
+      @client.send_data(evaluate_request(@client.next_seq_id, '$mid_var = \'middle\'', 0))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      expect(result['body']['result']).to eq('middle')
+
+      # -----
+      # Change the function break points from alert to notice, mid-debug which should be line 43
+      #
+      # set_function_breakpoints_request
+      @client.send_data(set_function_breakpoints_request(@client.next_seq_id,
+        {
+          'breakpoints' => [
+            { 'name' => 'notice' }
+          ]
+        }
+      ))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      # Ensure the breakpoint response is as expected
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      expect(result['body']['breakpoints'][0]['verified']).to be true
+
+      # -----
+      # Step out of nested class, back into democlass
+      # Line 29
+      #
+      @client.clear_messages!
+      @client.send_data(stepout_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_event_within_timeout(['stopped', 10])
+      result = @client.data_from_event_name('stopped')
+
+      # Get the stack trace list
+      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      # The stack should be two levels deep (root -> democlass)
+      expect(result['success']).to be true
+      expect(result['body']['stackFrames'].count).to eq(2)
+      expect(result['body']['stackFrames'][0]).to include('line' => 29)
+      expect(result['body']['stackFrames'][1]).to include('line' => 39)
+
+      # ----
+      # Dymically change the breakpoint list
+      #
+      # set_breakpoints_request
+      @client.send_data(set_breakpoints_request(@client.next_seq_id,
+        {
+          'source'      => {
+            'name' => 'kitchen_sink.pp',
+            'path' => manifest_file
+          },
+          'breakpoints' => [
+            { 'line' => 3  }, # This breakpoint is on a comment line and should not be verified
+            { 'line' => 41 }
+          ]
+        }
+      ))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      # Ensure the breakpoint response is as expected
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      expect(result['success']).to eq('true')
+      # Breakpoint on a comment line
+      expect(result['body']['breakpoints'][0]['verified']).to be false
+      expect(result['body']['breakpoints'][0]['message']).to match(/Line does not exist or is blank/)
+      # Breakpoint at root of manifest
+      expect(result['body']['breakpoints'][1]['verified']).to be true
+
+      # Wait for the breakpoint to be hit
+      @client.clear_messages!
+      @client.send_data(continue_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_event_within_timeout(['stopped', 60])
+      result = @client.data_from_event_name('stopped')
+      expect(result['body']['reason']).to eq('breakpoint')
+      thread_id = result['body']['threadId']
+
+      # Get the stack trace list
+      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      # As we're only in the root, only one frame should be available
+      expect(result['success']).to be true
+      expect(result['body']['stackFrames'].count).to eq(1)
+      expect(result['body']['stackFrames'][0]).to include('line' => 41)
+
+      # ---
+      # Clear all breakpoints
+      #
+      # set_breakpoints_request
+      @client.send_data(set_breakpoints_request(@client.next_seq_id,
+        {
+          'source'      => {
+            'name' => 'kitchen_sink.pp',
+            'path' => manifest_file
+          },
+          'breakpoints' => []
+        }
+      ))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      # Ensure the breakpoint response is as expected
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      expect(result['success']).to eq('true')
+
+      # -----
+      # Now we wait to hit the notice function which is in the root
+      # Line 43
+      # -----
+
+      # Wait for the breakpoint to be hit
+      @client.clear_messages!
+      @client.send_data(continue_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_event_within_timeout(['stopped', 60])
+      result = @client.data_from_event_name('stopped')
+      expect(result['body']['reason']).to eq('function breakpoint')
+      expect(result['body']['description']).to eq('notice')
+      thread_id = result['body']['threadId']
+
+      # Get the stack trace list
+      @client.send_data(stacktrace_request(@client.next_seq_id, thread_id))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      # As we're only in the root, only one frame should be available
+      expect(result['success']).to be true
+      expect(result['body']['stackFrames'].count).to eq(1)
+      expect(result['body']['stackFrames'][0]).to include('line' => 43)
+
+      # Evaluate that $mid_var still exists
+      @client.send_data(evaluate_request(@client.next_seq_id, '$mid_var', 0))
+      expect(@client).to receive_message_with_request_id_within_timeout([@client.current_seq_id, 5])
+      result = @client.data_from_request_seq_id(@client.current_seq_id)
+      expect(result['body']['result']).to eq('middle')
+
+      @client.send_data(continue_request(@client.next_seq_id, thread_id))
+
+      # Wait for the puppet run to complete
+      expect(@client).to receive_event_within_timeout(['terminated', 60])
+
+      # Make sure we received the exited event
+      result = @client.data_from_event_name('exited')
+      expect(result).to_not be nil
+      expect(result['body']['exitCode']).to eq(0)
+    end
+  end
+end

--- a/server/spec/debugserver/integration/puppet-debugserver/message_router_spec.rb
+++ b/server/spec/debugserver/integration/puppet-debugserver/message_router_spec.rb
@@ -1,0 +1,122 @@
+require 'spec_debug_helper'
+require 'json'
+
+# A stubbed JSON Handler which is used to remember data sent to the client
+class StubbedMessageRouter < PuppetDebugServer::MessageRouter
+  attr_reader :data_stream
+
+  def initialize(*options)
+    super(*options)
+    @data_stream = []
+  end
+
+  def send_data(data)
+    # Strip the Content Header
+    stripped_data = data.slice(data.index("\r\n\r\n") + 4 ..-1)
+    @data_stream << JSON.parse(stripped_data)
+    true
+  end
+end
+
+# Helper methods that look at the stubbed message for various
+# messages in the queue.
+def data_from_request_seq_id(obj, request_seq_id)
+  obj.data_stream.find { |item| item['request_seq'] == request_seq_id}
+end
+
+def data_from_event_name(obj, event_name)
+  obj.data_stream.find { |item| item['type'] == 'event' && item['event'] == event_name}
+end
+
+def next_seq_id
+  @tx_seq_id += 1
+end
+
+describe 'PuppetDebugServer::MessageRouter' do
+  let(:subject) { StubbedMessageRouter.new({}) }
+
+  before(:each) {
+    allow(subject).to receive(:close_connection_after_writing).and_return(true)
+    allow(subject).to receive(:close_connection).and_return(true)
+
+    PuppetDebugServer::PuppetDebugSession.stop
+    @tx_seq_id = 0
+  }
+
+  context 'During initial session setup' do
+    it 'should respond with the correct capabilities' do
+      subject.parse_data(initialize_request)
+
+      response = data_from_request_seq_id(subject, 1)
+
+      expect(response['body']['supportsConfigurationDoneRequest']).to be true
+      expect(response['body']['supportsFunctionBreakpoints']).to be true
+      expect(response['body']['supportsRestartRequest']).to be false
+      expect(response['body']['supportsStepBack']).to be false
+      expect(response['body']['supportsSetVariable']).to be true
+      expect(response['body']['supportsStepInTargetsRequest']).to be false
+      expect(response['body']['supportedChecksumAlgorithms']).to eq([])
+    end
+
+    it 'should respond with an Initialized event' do
+      subject.parse_data(initialize_request)
+
+      response = data_from_event_name(subject, 'initialized')
+      expect(response).to_not be nil
+    end
+
+    it 'should respond with failures for debug session commands' do
+      subject.parse_data(initialize_request)
+      subject.parse_data(threads_request(2))
+      subject.parse_data(stacktrace_request(3))
+      subject.parse_data(scopes_request(4))
+      subject.parse_data(variables_request(5))
+      subject.parse_data(evaluate_request(6))
+      subject.parse_data(stepin_request(7))
+      subject.parse_data(stepout_request(8))
+      subject.parse_data(next_request(9))
+
+      {
+        2 => 'threads',
+        3 => 'stackTrace',
+        4 => 'scopes',
+        5 => 'variables',
+        6 => 'evaluate',
+        7 => 'stepIn',
+        8 => 'stepOut',
+        9 => 'next',
+      }.each do |seq_id, command|
+        response = data_from_request_seq_id(subject, seq_id)
+        expect(response).to_not be nil
+        expect(response['success']).to be false
+        expect(response['command']).to eq(command)
+      end
+    end
+
+    it 'should increment the response sequence ID by one' do
+      subject.parse_data(initialize_request)
+      subject.parse_data(threads_request(10))
+      subject.parse_data(stacktrace_request(20))
+      subject.parse_data(scopes_request(30))
+
+      last_seq_id = nil
+      [10, 20, 30].each do |req_seq_id|
+        response = data_from_request_seq_id(subject, req_seq_id)
+        expect(response).to_not be nil
+        expect(response['success']).to be false
+        unless last_seq_id.nil?
+          expect(response['seq']).to eq(last_seq_id + 1)
+        end
+        last_seq_id = response['seq']
+      end
+    end
+  end
+
+  context 'Receiving a disconnect request' do
+    it 'should close the connection' do
+      expect(subject).to receive(:close_connection)
+      subject.parse_data(initialize_request)
+      subject.parse_data(disconnect_request(2))
+    end
+  end
+end

--- a/server/spec/debugserver/spec_debug_client.rb
+++ b/server/spec/debugserver/spec_debug_client.rb
@@ -1,0 +1,160 @@
+# The end-to-end testing file starts a debug server as part of the testing.  This class is used
+# to send and receive messages to the server.
+#
+# By setting the `SPEC_DEBUG` environment variable, it will display debug information to the console
+# while the tests are being run.  This can be useful when figuring out why tests have failed
+
+class DebugClient
+  attr_reader :received_messages
+
+  def initialize(host, port)
+    @socket = TCPSocket.open(host, port)
+    @buffer = []
+    @received_messages = []
+    @new_messages = false
+    @tx_seq_id = 0
+  end
+
+  # Have any new messages been received since data has been sent to the server
+  def new_messages?
+    @new_messages
+  end
+
+  # Send data to the server
+  def send_data(json_string)
+    size = json_string.bytesize
+    @new_messages = false
+    puts "... Sent: #{json_string}" if ENV['SPEC_DEBUG']
+    @socket.write("Content-Length: #{size}\r\n\r\n" + json_string)
+  end
+
+  # The current sequence ID.  Used when sending messages
+  def current_seq_id
+    @tx_seq_id
+  end
+
+  # Return the next sequence ID
+  def next_seq_id
+    @tx_seq_id += 1
+  end
+
+  # Find the first message received that has the specfied request_sequence ID
+  # Used when trying to find responses to requests
+  def data_from_request_seq_id(request_seq_id)
+    received_messages.find { |item| item['request_seq'] == request_seq_id}
+  end
+
+  # Find the first message received that has the specfied event name
+  def data_from_event_name(event_name)
+    received_messages.find { |item| item['type'] == 'event' && item['event'] == event_name}
+  end
+
+  # Drains and processes any data send from the server to the client
+  def read_data
+    output = []
+    # Adapted from the PowerShell manager.  Need to change it
+    read_from_stream(@socket, 0.5) { |s| output << s }
+
+    # there's ultimately a bit of a race here
+    # read one more time after signal is received
+    read_from_stream(@socket, 0) { |s| output << s }
+
+    # string has been binary up to this point, so force UTF-8 now
+    receive_data(output.join('').force_encoding(Encoding::UTF_8)) unless output.empty?
+  end
+
+  # Closes the TCP connection
+  def close
+    @socket.close
+  end
+
+  # Is the conection closed?
+  def closed?
+    @socket.closed?
+  end
+
+  # Clear the received messages list
+  def clear_messages!
+    @received_messages = []
+  end
+
+  private
+
+  def parse_data(data)
+    puts "... Received: #{data}" if ENV['SPEC_DEBUG']
+    @received_messages << JSON.parse(data)
+    @new_messages = true
+  end
+
+  def extract_headers(raw_header)
+    header = {}
+    raw_header.split("\r\n").each do |item|
+      name, value = item.split(':', 2)
+
+      if name.casecmp('Content-Length').zero?
+        header['Content-Length'] = value.strip.to_i
+      elsif name.casecmp('Content-Type').zero?
+        header['Content-Length'] = value.strip
+      else
+        raise("Unknown header #{name} in Debug Server message")
+      end
+    end
+    header
+  end
+
+  def receive_data(data)
+    return if data.empty?
+    return if @state == :ignore
+
+    @buffer += data.bytes
+
+    while @buffer.length > 4
+      # Check if we have enough data for the headers
+      # Need to find the first instance of '\r\n\r\n'
+      offset = 0
+      while offset < @buffer.length - 4
+        break if @buffer[offset] == 13 && @buffer[offset + 1] == 10 && @buffer[offset + 2] == 13 && @buffer[offset + 3] == 10
+        offset += 1
+      end
+      return unless offset < @buffer.length - 4
+
+      # Extract the headers
+      raw_header = @buffer.slice(0, offset).pack('C*').force_encoding('ASCII') # Note the headers are always ASCII encoded
+      headers = extract_headers(raw_header)
+      raise('Missing Content-Length header') if headers['Content-Length'].nil?
+
+      # Now we have the headers and the content length, do we have enough data now
+      minimum_buf_length = offset + 3 + headers['Content-Length'] + 1 # Need to add one as we're converting from offset (zero based) to length (1 based) arrays
+      return if @buffer.length < minimum_buf_length
+
+      # Extract the message content
+      content = @buffer.slice(offset + 3 + 1, headers['Content-Length']).pack('C*').force_encoding('utf-8') # TODO: default is utf-8.  Need to enode based on Content-Type
+      # Purge the buffer
+      @buffer = @buffer.slice(minimum_buf_length, @buffer.length - minimum_buf_length)
+      @buffer = [] if @buffer.nil?
+
+      parse_data(content)
+    end
+  end
+
+  def is_stream_valid?(stream)
+    !stream.closed? && !stream.stat.nil?
+  rescue # Ignore an errors
+    false
+  end
+
+  def is_readable?(stream, timeout = 0.5)
+    raise Errno::EPIPE if !is_stream_valid?(stream)
+    read_ready = IO.select([stream], [], [], timeout)
+    read_ready && stream == read_ready[0][0]
+  end
+
+  def read_from_stream(stream, timeout = 0.1, &block)
+    if is_readable?(stream, timeout)
+      data = stream.readpartial(4096)
+      yield data unless data.nil?
+    end
+
+    nil
+  end
+end

--- a/server/spec/debugserver/spec_debug_helper.rb
+++ b/server/spec/debugserver/spec_debug_helper.rb
@@ -4,41 +4,234 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__),'..','lib'))
 
 require 'puppet-debugserver'
-fixtures_dir = File.join(File.dirname(__FILE__),'fixtures')
+# Normally globals are 'bad', but in this case it really should be global to all testing
+# code paths
+$fixtures_dir = File.join(File.dirname(__FILE__),'fixtures')
+$root_dir = File.join(File.dirname(__FILE__),'..','..')
 # Currently there is no way to re-initialize the puppet loader so for the moment
 # all tests must run off the single puppet config settings instead of per example setting
-puppet_settings = ['--vardir',File.join(fixtures_dir,'cache'),
-                   '--confdir',File.join(fixtures_dir,'confdir')]
+puppet_settings = ['--vardir',File.join($fixtures_dir,'cache'),
+                   '--confdir',File.join($fixtures_dir,'confdir')]
 PuppetDebugServer::init_puppet(PuppetDebugServer::CommandLineParser.parse([]))
 Puppet.initialize_settings(puppet_settings)
 
 # Custom RSpec Matchers
 
-# Mock ojects
-class MockJSONRPCHandler < PuppetDebugServer::JSONHandler
-  attr_accessor :socket
-  attr_accessor :simple_tcp_server
-
-  def post_init
-  end
-
-  def unbind
-  end
-
-  def receive_data(data)
-  end
-
-  def error?
+RSpec::Matchers.define :receive_message_with_request_id_within_timeout do |request_seq_id, timeout = 5|
+  match do |client|
+    exit_timeout = timeout
+    while exit_timeout > 0 do
+      puts "... Waiting for message with request id #{request_seq_id} (timeout #{exit_timeout}s)" if ENV['SPEC_DEBUG']
+      raise 'Client has been closed' if client.closed?
+      client.read_data
+      if client.new_messages?
+        data = client.data_from_request_seq_id(request_seq_id)
+        return true unless data.nil?
+      end
+      sleep(1)
+      exit_timeout -= 1
+    end
     false
   end
 
-  def send_data(data)
-    true
+  failure_message do |actual|
+    message =     "expected that client would event with request id '#{request_seq_id}' event within #{timeout} seconds\n"
+    message += "Last 5 messages\n"
+    client.received_messages.last(5).each { |item| message += "#{item}\n" }
+    message
+  end
+end
+
+RSpec::Matchers.define :receive_event_within_timeout do |event_name, timeout = 5|
+  match do |client|
+    exit_timeout = timeout
+    while exit_timeout > 0 do
+      puts "... Waiting for message with event '#{event_name}' (timeout #{exit_timeout}s)" if ENV['SPEC_DEBUG']
+      raise 'Client has been closed' if client.closed?
+      client.read_data
+      if client.new_messages?
+        data = client.data_from_event_name(event_name)
+        return true unless data.nil?
+      end
+      sleep(1)
+      exit_timeout -= 1
+    end
+    false
   end
 
-  def close_connection_after_writing
+  failure_message do |client|
+    message = "expected that client would recieve '#{event_name}' event within #{timeout} seconds\n"
+    message += "Last 5 messages\n"
+    client.received_messages.last(5).each { |item| message += "#{item}\n" }
+    message
   end
+end
 
-  def close_connection
-  end
+# Helpers
+def initialize_request(seq_id = 1)
+  JSON.generate({
+    'command'   => 'initialize',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+      'clientID'                     => 'vscode',
+      'adapterID'                    => 'Puppet',
+      'pathFormat'                   => 'path',
+      'linesStartAt1'                => true,
+      'columnsStartAt1'              => true,
+      'supportsVariableType'         => true,
+      'supportsVariablePaging'       => true,
+      'supportsRunInTerminalRequest' => true
+    }
+  })
+end
+
+def threads_request(seq_id = 1)
+  JSON.generate({
+    'command'   => 'threads',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {}
+  })
+end
+
+def stacktrace_request(seq_id = 1, thread_id = 0)
+  JSON.generate({
+    'command'   => 'stackTrace',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+      'threadId' => thread_id
+    }
+  })
+end
+
+def scopes_request(seq_id = 1, frame_id = 0)
+  JSON.generate({
+    'command'   => 'scopes',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+      'frameId' => frame_id
+    }
+  })
+end
+
+def variables_request(seq_id = 1, variables_reference = 0)
+  JSON.generate({
+    'command'   => 'variables',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+      'variablesReference' => variables_reference
+    }
+  })
+end
+
+def evaluate_request(seq_id = 1, expression = '', frameId = nil, context = nil)
+  result = JSON.generate({
+    'command'   => 'evaluate',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+      'expression' => expression,
+      'frameId'    => frameId,
+      'context'    => context
+    }
+  })
+end
+
+def stepin_request(seq_id = 1, thread_id = 0)
+  JSON.generate({
+    'command'   => 'stepIn',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+      'threadId' => thread_id
+    }
+  })
+end
+
+def stepout_request(seq_id = 1, thread_id = 0)
+  JSON.generate({
+    'command'   => 'stepOut',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+      'threadId' => thread_id
+    }
+  })
+end
+
+def next_request(seq_id = 1, thread_id = 0)
+  JSON.generate({
+    'command'   => 'next',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+      'threadId' => thread_id
+    }
+  })
+end
+
+def disconnect_request(seq_id = 1)
+  JSON.generate({
+    'command'   => 'disconnect',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+    }
+  })
+end
+
+def configuration_done_request(seq_id = 1)
+  JSON.generate({
+    'command'   => 'configurationDone',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+    }
+  })
+end
+
+def launch_request(seq_id = 1, manifest_file, noop, args)
+  JSON.generate({
+    'command'   => 'launch',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+      'manifest' => manifest_file,
+      'noop'     => noop,
+      'args'    => args
+    }
+  })
+end
+
+def continue_request(seq_id = 1, thread_id)
+  JSON.generate({
+    'command'   => 'continue',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => {
+      'threadId' => thread_id
+    }
+  })
+end
+
+def set_breakpoints_request(seq_id = 1, arguments)
+  JSON.generate({
+    'command'   => 'setBreakpoints',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => arguments
+  })
+end
+
+def set_function_breakpoints_request(seq_id = 1, arguments)
+  JSON.generate({
+    'command'   => 'setFunctionBreakpoints',
+    'type'      => 'request',
+    'seq'       => seq_id,
+    'arguments' => arguments
+  })
 end


### PR DESCRIPTION
Previously the evaluate hooks would be firing when the debug session was paused.
This means when doing string evaluations the POPS evaluation depth would be
modified and potentially other hooks (function, exception) would be firing in
error.  This commit guards the evaluation hooks to exit early if the session is
paused.

This commit also fixes a bug in the after evaluation hook which was decrementing
the counter back to zero, which then broke the Step Out functionality.  This
commit changes the functionality to only decrement by one per invocation.

---

Previously the sequence number was doubling instead of incrementing by one. This
was due to a previous typo.  This commit changes the increment to one.

---

Previously, generating the stack frame list was raising errors due to Puppet 4
not exposing the same methods.  This was mostly fixed in 6740faf however
the stack frames were not testable.  This commit changes the location detection
to use the same helper methods created in 6740faf and also adds the
pos_on_line helper method.

---

Previously due to puppetlabs/puppet@0f96dd9
the stack trace from puppet was being output in the reverse order.  This commit
reverts the order for Puppet 4.7.x and below, to mirror that of version 4.8.0
and above.

---

Previously the test coverage on the debug server was minimal.  This commit adds
integration tests for the debug server.  In particular it starts a debug server
as a separate process and emulates debug client TCP messages.  The kitchen sink
test file, tests all of the features of the debug server.