### PR TITLE
(GH-218) Add support and validation of EPP files

### DIFF
--- a/server/lib/puppet-languageserver/document_validator.rb
+++ b/server/lib/puppet-languageserver/document_validator.rb
@@ -51,6 +51,36 @@ module PuppetLanguageServer
       [problems_fixed, linter.manifest]
     end
 
+    def self.validate_epp(content, _workspace, _max_problems = 100)
+      result = []
+      # TODO: Need to implement max_problems
+      _problems = 0
+
+      begin
+        parser = Puppet::Pops::Parser::EvaluatingParser::EvaluatingEppParser.new
+        parser.parse_string(content, nil)
+      rescue StandardError => detail
+        # Sometimes the error is in the cause not the root object itself
+        detail = detail.cause if !detail.respond_to?(:line) && detail.respond_to?(:cause)
+        ex_line = detail.respond_to?(:line) && !detail.line.nil? ? detail.line - 1 : nil # Line numbers from puppet exceptions are base 1
+        ex_pos = detail.respond_to?(:pos) && !detail.pos.nil? ? detail.pos : nil # Pos numbers from puppet are base 1
+
+        message = detail.respond_to?(:message) ? detail.message : nil
+        message = detail.basic_message if message.nil? && detail.respond_to?(:basic_message)
+
+        unless ex_line.nil? || ex_pos.nil? || message.nil?
+          result << LanguageServer::Diagnostic.create('severity' => LanguageServer::DIAGNOSTICSEVERITY_ERROR,
+                                                      'fromline' => ex_line,
+                                                      'toline' => ex_line,
+                                                      'fromchar' => ex_pos,
+                                                      'tochar' => ex_pos + 1,
+                                                      'source' => 'Puppet',
+                                                      'message' => message)
+        end
+      end
+      result
+    end
+
     def self.validate(content, workspace, _max_problems = 100)
       result = []
       # TODO: Need to implement max_problems

--- a/server/lib/puppet-languageserver/message_router.rb
+++ b/server/lib/puppet-languageserver/message_router.rb
@@ -284,6 +284,8 @@ TEXT
         case document_type(file_uri)
         when :manifest
           reply_diagnostics(file_uri, PuppetLanguageServer::DocumentValidator.validate(content, @workspace))
+        when :epp
+          reply_diagnostics(file_uri, PuppetLanguageServer::DocumentValidator.validate_epp(content, @workspace))
         else
           reply_diagnostics(file_uri, [])
         end
@@ -301,6 +303,8 @@ TEXT
         case document_type(file_uri)
         when :manifest
           reply_diagnostics(file_uri, PuppetLanguageServer::DocumentValidator.validate(content, @workspace))
+        when :epp
+          reply_diagnostics(file_uri, PuppetLanguageServer::DocumentValidator.validate_epp(content, @workspace))
         else
           reply_diagnostics(file_uri, [])
         end

--- a/server/lib/puppet-vscode/simple_tcp_server.rb
+++ b/server/lib/puppet-vscode/simple_tcp_server.rb
@@ -31,13 +31,14 @@ module PuppetVSCode
 
     # @api public
     def send_data(data)
+      return false if socket.nil?
       socket.write(data)
       true
     end
 
     # @api public
     def close_connection_after_writing
-      socket.flush
+      socket.flush unless socket.nil?
       simple_tcp_server.remove_connection_async(socket)
     end
 

--- a/server/spec/languageserver/integration/puppet-languageserver/document_validator_spec.rb
+++ b/server/spec/languageserver/integration/puppet-languageserver/document_validator_spec.rb
@@ -99,6 +99,35 @@ describe 'document_validator' do
     end
   end
 
+  describe '#valide_epp' do
+    describe "Given an EPP which has a syntax error" do
+      let(:template) { '<%- String $tmp
+      | -%>
+
+      <%= $tmp %>' }
+
+      it "should return a single syntax error" do
+        result = subject.validate_epp(template, nil)
+        expect(result.length).to be > 0
+        expect(result[0]['range']['start']['line']).to eq(1)
+        expect(result[0]['range']['start']['character']).to eq(7)
+        expect(result[0]['range']['end']['line']).to eq(1)
+        expect(result[0]['range']['end']['character']).to eq(8)
+      end
+    end
+
+    describe "Given a complete EPP which has no syntax errors" do
+      let(:template) { '<%- | String $tmp
+      | -%>
+
+      <%= $tmp %>' }
+
+      it "should return an empty array" do
+        expect(subject.validate_epp(template, nil)).to eq([])
+      end
+    end
+  end
+
   describe '#validate' do
     describe "Given an incomplete manifest which has syntax errors" do
       let(:manifest) { 'user { "Bob"' }

--- a/server/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
+++ b/server/spec/languageserver/unit/puppet-languageserver/message_router_spec.rb
@@ -582,9 +582,10 @@ describe 'message_router' do
 
       context 'for an EPP template file' do
         before(:each) do
+          expect(PuppetLanguageServer::DocumentValidator).to receive(:validate_epp).and_return(validation_result)
           allow(subject).to receive(:reply_diagnostics).and_return(true)
         end
-        it_should_behave_like "an opened document with no validation errors", EPP_FILENAME, ERROR_CAUSING_FILE_CONTENT
+        it_should_behave_like "an opened document with validation errors", EPP_FILENAME, ERROR_CAUSING_FILE_CONTENT
       end
 
       context 'for an unknown file' do
@@ -696,9 +697,10 @@ describe 'message_router' do
 
       context 'for an EPP template file' do
         before(:each) do
+          expect(PuppetLanguageServer::DocumentValidator).to receive(:validate_epp).and_return(validation_result)
           allow(subject).to receive(:reply_diagnostics).and_return(true)
         end
-        it_should_behave_like "a changed document with no validation errors", EPP_FILENAME, ERROR_CAUSING_FILE_CONTENT
+        it_should_behave_like "a changed document with validation errors", EPP_FILENAME, ERROR_CAUSING_FILE_CONTENT
       end
 
       context 'for a file the server does not understand' do


### PR DESCRIPTION
Previously the language server thought all files were a puppet manifest.  This
commit adds a helper function to detect document type via name.  This commit
also modifies the message router to change it's responses based on the file
type.

---

Previously the language server assumed all files were Puppet manifests however
the language server also supports EPP files.  This commit adds basic validation
for EPP files (diagnostics on open and edit).