### PR TITLE
(maint) Update syntax highlighting

### DIFF
--- a/client/syntaxes/puppet.tmLanguage
+++ b/client/syntaxes/puppet.tmLanguage
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+  <key>scopeName</key>
+  <string>source.puppet</string>
   <key>fileTypes</key>
   <array>
     <string>pp</string>
@@ -10,8 +12,6 @@
   <string>(^\s*/\*|(\{|\[|\()\s*$)</string>
   <key>foldingStopMarker</key>
   <string>(\*/|^\s*(\}|\]|\)))</string>
-  <key>keyEquivalent</key>
-  <string>^~P</string>
   <key>name</key>
   <string>Puppet</string>
   <key>patterns</key>
@@ -19,6 +19,10 @@
     <dict>
       <key>include</key>
       <string>#line_comment</string>
+    </dict>
+    <dict>
+      <key>include</key>
+      <string>#constants</string>
     </dict>
     <dict>
       <key>begin</key>
@@ -30,9 +34,7 @@
     </dict>
     <dict>
       <key>begin</key>
-      <string>(?x)^\s*
-          (node|class)\s+
-          ((?:[-_A-Za-z0-9".]+::)*[-_A-Za-z0-9".]+)\s* # identifier</string>
+      <string>^\s*(node|class)\s+((?:[-_A-Za-z0-9"\'.]+::)*[-_A-Za-z0-9"\'.]+)\s*</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -53,30 +55,6 @@
       <key>patterns</key>
       <array>
         <dict>
-          <key>include</key>
-          <string>#puppet-datatypes</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#variables</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#constants</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#strings</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#numbers</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#line_comment</string>
-        </dict>
-        <dict>
           <key>begin</key>
           <string>\b(inherits)\b\s+</string>
           <key>captures</key>
@@ -88,7 +66,7 @@
             </dict>
           </dict>
           <key>end</key>
-          <string>(?={)</string>
+          <string>(?=\(|{)</string>
           <key>name</key>
           <string>meta.definition.class.inherits.puppet</string>
           <key>patterns</key>
@@ -101,14 +79,74 @@
             </dict>
           </array>
         </dict>
+        <dict>
+          <key>include</key>
+          <string>#line_comment</string>
+        </dict>
+        <!-- `$param,` -->
+        <dict>
+          <key>captures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>variable.other.puppet</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.variable.puppet</string>
+            </dict>
+          </dict>
+          <key>match</key>
+          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))</string>
+          <key>name</key>
+          <string>meta.function.argument.puppet</string>
+        </dict>
+        <!-- `$param = ...,` -->
+        <dict>
+          <key>begin</key>
+          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*</string>
+          <key>captures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>variable.other.puppet</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.variable.puppet</string>
+            </dict>
+            <key>3</key>
+            <dict>
+              <key>name</key>
+              <string>keyword.operator.assignment.puppet</string>
+            </dict>
+          </dict>
+          <key>end</key>
+          <string>(?=,|\))</string>
+          <key>name</key>
+          <string>meta.function.argument.puppet</string>
+          <key>patterns</key>
+          <array>
+            <dict>
+              <key>include</key>
+              <string>#parameter-default-types</string>
+            </dict>
+          </array>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#parameter-default-types</string>
+        </dict>
       </array>
     </dict>
     <!-- Ref https://puppet.com/docs/bolt/0.x/writing_plans.html#naming-plans -->
     <dict>
       <key>begin</key>
-      <string>(?x)^\s*
-          (plan)\s+
-          ((?:[a-z][a-z0-9_]+::)*[a-z][a-z0-9_]+)\s* # identifier</string>
+      <string>^\s*(plan)\s+((?:[a-z][a-z0-9_]+::)*[a-z][a-z0-9_]+)\s*</string>
       <key>captures</key>
       <dict>
         <key>1</key>
@@ -130,33 +168,71 @@
       <array>
         <dict>
           <key>include</key>
-          <string>#puppet-datatypes</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#variables</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#constants</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#strings</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#numbers</string>
-        </dict>
-        <dict>
-          <key>include</key>
           <string>#line_comment</string>
+        </dict>
+        <!-- `$param,` -->
+        <dict>
+          <key>captures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>variable.other.puppet</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.variable.puppet</string>
+            </dict>
+          </dict>
+          <key>match</key>
+          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))</string>
+          <key>name</key>
+          <string>meta.function.argument.puppet</string>
+        </dict>
+        <!-- `$param = ...,` -->
+        <dict>
+          <key>begin</key>
+          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*</string>
+          <key>captures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>variable.other.puppet</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.variable.puppet</string>
+            </dict>
+            <key>3</key>
+            <dict>
+              <key>name</key>
+              <string>keyword.operator.assignment.puppet</string>
+            </dict>
+          </dict>
+          <key>end</key>
+          <string>(?=,|\))</string>
+          <key>name</key>
+          <string>meta.function.argument.puppet</string>
+          <key>patterns</key>
+          <array>
+            <dict>
+              <key>include</key>
+              <string>#parameter-default-types</string>
+            </dict>
+          </array>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#parameter-default-types</string>
         </dict>
       </array>
     </dict>
     <dict>
       <key>begin</key>
-      <string>^\s*(define)\s+([a-zA-Z0-9_:]+)\s*(\()</string>
+      <string>^\s*(define|function)\s+([a-zA-Z0-9_:]+)\s*(\()</string>
       <key>beginCaptures</key>
       <dict>
         <key>1</key>
@@ -206,13 +282,13 @@
             </dict>
           </dict>
           <key>match</key>
-          <string>((\$+)[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*)\s*(?=,|\))</string>
+          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)\s*(?=,|\))</string>
           <key>name</key>
           <string>meta.function.argument.no-default.puppet</string>
         </dict>
         <dict>
           <key>begin</key>
-          <string>((\$+)[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*)(?:\s*(=)\s*)\s*</string>
+          <string>((\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\s*(=)\s*)\s*</string>
           <key>captures</key>
           <dict>
             <key>1</key>
@@ -260,21 +336,34 @@
         </dict>
       </dict>
       <key>match</key>
-      <string>^\s*(\S+)\s*{\s*(['"].+['"]):</string>
+      <string>^\s*(\w+)\s*{\s*([\'"].+[\'"]):</string>
       <key>name</key>
       <string>meta.definition.resource.puppet</string>
     </dict>
     <dict>
       <key>match</key>
-      <string>\b(case|if|unless|else|elsif)(?!::)</string>
+      <string>^\s*(\w+)\s*{\s*(\$[a-zA-Z_]+)\s*:</string>
+      <key>captures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>storage.type.puppet</string>
+        </dict>
+        <key>2</key>
+        <dict>
+          <key>name</key>
+          <string>entity.name.section.puppet</string>
+        </dict>
+      </dict>
       <key>name</key>
-      <string>keyword.control.puppet</string>
+      <string>meta.definition.resource.puppet</string>
     </dict>
     <dict>
       <key>match</key>
-      <string>((\$?)"?[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*"?):(?=\s+|$)</string>
+      <string>\b(case|if|else|elsif|unless)(?!::)\b</string>
       <key>name</key>
-      <string>entity.name.section.puppet</string>
+      <string>keyword.control.puppet</string>
     </dict>
     <dict>
       <key>include</key>
@@ -286,6 +375,16 @@
     </dict>
     <dict>
       <key>include</key>
+      <string>#array</string>
+    </dict>
+    <dict>
+      <key>match</key>
+      <string>((\$?)"?[a-zA-Z_\x{7f}-\x{ff}][a-zA-Z0-9_\x{7f}-\x{ff}]*"?):(?=\s+|$)</string>
+      <key>name</key>
+      <string>entity.name.section.puppet</string>
+    </dict>
+    <dict>
+      <key>include</key>
       <string>#numbers</string>
     </dict>
     <dict>
@@ -293,12 +392,8 @@
       <string>#variable</string>
     </dict>
     <dict>
-      <key>include</key>
-      <string>#constants</string>
-    </dict>
-    <dict>
       <key>begin</key>
-      <string>(?i)\b(import|include)\b\s*</string>
+      <string>\b(import|include|contain|require)\s+(?!.*=>)</string>
       <key>beginCaptures</key>
       <dict>
         <key>1</key>
@@ -326,9 +421,15 @@
     </dict>
     <dict>
       <key>match</key>
-      <string>\b(escape|gsub|alert|crit|debug|notice|defined|emerg|err|failed|file|generate|include|info|realize|search|tag|tagged|template|warning)\b</string>
+      <string>\b(alert|crit|debug|defined|emerg|err|escape|fail|failed|file|generate|gsub|info|notice|package|realize|search|tag|tagged|template|warning)\b(?!.*{)</string>
       <key>name</key>
       <string>support.function.puppet</string>
+    </dict>
+    <dict>
+      <key>match</key>
+      <string>=></string>
+      <key>name</key>
+      <string>punctuation.separator.key-value.puppet</string>
     </dict>
   </array>
   <key>repository</key>
@@ -339,7 +440,7 @@
       <array>
         <dict>
           <key>match</key>
-          <string>(?i)\b(false|true|running|undef|present|absent|file|directory)\b</string>
+          <string>\b(absent|directory|false|file|present|running|stopped|true)\b(?!.*{)</string>
           <key>name</key>
           <string>constant.language.puppet</string>
         </dict>
@@ -612,45 +713,95 @@
           <string>#variables</string>
         </dict>
         <dict>
-          <key>match</key>
-          <string>=</string>
-          <key>name</key>
-          <string>keyword.operator.assignment.php</string>
+          <key>include</key>
+          <string>#hash</string>
         </dict>
         <dict>
-          <key>begin</key>
-          <string>(\[)</string>
-          <key>beginCaptures</key>
-          <dict>
-            <key>1</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.array.begin.puppet</string>
-            </dict>
-          </dict>
-          <key>end</key>
-          <string>\]</string>
-          <key>endCaptures</key>
-          <dict>
-            <key>0</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.array.end.puppet</string>
-            </dict>
-          </dict>
-          <key>name</key>
-          <string>meta.array.php</string>
-          <key>patterns</key>
-          <array>
-            <dict>
-              <key>include</key>
-              <string>#parameter-default-types</string>
-            </dict>
-          </array>
+          <key>include</key>
+          <string>#array</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#function_call</string>
         </dict>
         <dict>
           <key>include</key>
           <string>#constants</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#puppet-datatypes</string>
+        </dict>
+      </array>
+    </dict>
+
+    <key>array</key>
+    <dict>
+      <key>begin</key>
+      <string>(\[)</string>
+      <key>beginCaptures</key>
+      <dict>
+        <key>1</key>
+        <dict>
+          <key>name</key>
+          <string>punctuation.definition.array.begin.puppet</string>
+        </dict>
+      </dict>
+      <key>end</key>
+      <string>\]</string>
+      <key>endCaptures</key>
+      <dict>
+        <key>0</key>
+        <dict>
+          <key>name</key>
+          <string>punctuation.definition.array.end.puppet</string>
+        </dict>
+      </dict>
+      <key>name</key>
+      <string>meta.array.puppet</string>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>#parameter-default-types</string>
+        </dict>
+      </array>
+    </dict>
+    <key>hash</key>
+    <dict>
+      <key>begin</key>
+      <string>\{</string>
+      <key>beginCaptures</key>
+      <dict>
+        <key>0</key>
+        <dict>
+          <key>name</key>
+          <string>punctuation.definition.hash.begin.puppet</string>
+        </dict>
+      </dict>
+      <key>end</key>
+      <string>\}</string>
+      <key>endCaptures</key>
+      <dict>
+        <key>0</key>
+        <dict>
+          <key>name</key>
+          <string>punctuation.definition.hash.end.puppet</string>
+        </dict>
+      </dict>
+      <key>name</key>
+      <string>meta.hash.puppet</string>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>match</key>
+          <string>\b\w+\s*(?==>)\s*</string>
+          <key>name</key>
+          <string>constant.other.key.puppet</string>
+        </dict>
+        <dict>
+          <key>include</key>
+          <string>#parameter-default-types</string>
         </dict>
       </array>
     </dict>
@@ -700,45 +851,6 @@
         </dict>
       </array>
     </dict>
-    <key>variable</key>
-    <dict>
-      <key>patterns</key>
-      <array>
-        <dict>
-          <key>captures</key>
-          <dict>
-            <key>1</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.variable.puppet</string>
-            </dict>
-          </dict>
-          <key>match</key>
-          <string>(\$)([a-zA-Zx7f-xff\$]|::)([a-zA-Z0-9_x7f-xff\$]|::)*\b</string>
-          <key>name</key>
-          <string>variable.other.readwrite.global.puppet</string>
-        </dict>
-        <dict>
-          <key>captures</key>
-          <dict>
-            <key>1</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.variable.puppet</string>
-            </dict>
-            <key>2</key>
-            <dict>
-              <key>name</key>
-              <string>punctuation.definition.variable.puppet</string>
-            </dict>
-          </dict>
-          <key>match</key>
-          <string>(\$\{)(?:[a-zA-Zx7f-xff\$]|::)(?:[a-zA-Z0-9_x7f-xff\$]|::)*(\})</string>
-          <key>name</key>
-          <string>variable.other.readwrite.global.puppet</string>
-        </dict>
-      </array>
-    </dict>
     <!-- Ref https://github.com/puppetlabs/puppet-specifications/blob/master/language/lexical_structure.md#numbers -->
     <key>numbers</key>
     <dict>
@@ -773,84 +885,82 @@
         </dict>
       </array>
     </dict>
+    <key>variable</key>
+    <dict>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>captures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.variable.puppet</string>
+            </dict>
+          </dict>
+          <key>match</key>
+          <string>(\$)((::)?[a-z]\w*)*((::)?[a-z_]\w*)\b</string>
+          <key>name</key>
+          <string>variable.other.readwrite.global.puppet</string>
+        </dict>
+        <dict>
+          <key>captures</key>
+          <dict>
+            <key>1</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.variable.puppet</string>
+            </dict>
+            <key>2</key>
+            <dict>
+              <key>name</key>
+              <string>punctuation.definition.variable.puppet</string>
+            </dict>
+          </dict>
+          <key>match</key>
+          <string>(\$\{)(?:[a-zA-Zx7f-xff\$]|::)(?:[a-zA-Z0-9_x7f-xff\$]|::)*(\})</string>
+          <key>name</key>
+          <string>variable.other.readwrite.global.puppet</string>
+        </dict>
+      </array>
+    </dict>
+    <key>function_call</key>
+    <dict>
+      <key>begin</key>
+      <string>([a-zA-Z_][a-zA-Z0-9_]*)(\()</string>
+      <key>end</key>
+      <string>\)</string>
+      <key>name</key>
+      <string>meta.function-call.puppet</string>
+      <key>patterns</key>
+      <array>
+        <dict>
+          <key>include</key>
+          <string>#parameter-default-types</string>
+        </dict>
+        <dict>
+          <key>match</key>
+          <string>,</string>
+          <key>name</key>
+          <string>punctuation.separator.parameters.puppet</string>
+        </dict>
+      </array>
+    </dict>
     <!-- Ref: https://github.com/puppetlabs/puppet-specifications/blob/master/language/types_values_variables.md#the-type-system -->
     <key>puppet-datatypes</key>
     <dict>
       <key>patterns</key>
       <array>
         <dict>
-          <key>include</key>
-          <string>#puppet-datatype-noparameters</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#puppet-datatype-withparameters</string>
-        </dict>
-      </array>
-    </dict>
-    <key>puppet-datatype-noparameters</key>
-    <dict>
-      <key>begin</key>
-      <string>(?:\s|,|^)([A-Z][a-zA-Z]*)(?:\s|])</string>
-      <key>beginCaptures</key>
-      <dict>
-        <key>1</key>
-        <dict>
+          <key>comment</key>
+          <string>Puppet Data type</string>
+          <key>match</key>
+          <string>(?&lt;![a-zA-Z\$])([A-Z][a-zA-Z]*)(?![a-zA-Z])</string>
           <key>name</key>
-          <string>entity.other.attribute-name.datatype.puppet</string>
-        </dict>
-      </dict>
-      <key>end</key>
-      <string>\b|\$</string>
-      <key>endCaptures</key>
-      <dict />
-    </dict>
-    <key>puppet-datatype-withparameters</key>
-    <dict>
-      <key>begin</key>
-      <string>(\b[A-Z][a-zA-Z]*)\[</string>
-      <key>beginCaptures</key>
-      <dict>
-        <key>1</key>
-        <dict>
-          <key>name</key>
-          <string>entity.other.attribute-name.datatype.puppet</string>
-        </dict>
-      </dict>
-      <key>end</key>
-      <string>(?=\])</string>
-      <key>endCaptures</key>
-      <dict>
-        <key>1</key>
-        <dict>
-          <key>name</key>
-          <string>entity.other.attribute-name.datatype.puppet</string>
-        </dict>
-      </dict>
-      <key>patterns</key>
-      <array>
-        <dict>
-          <key>include</key>
-          <string>#puppet-datatype-withparameters</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#puppet-datatype-noparameters</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#strings</string>
-        </dict>
-        <dict>
-          <key>include</key>
-          <string>#numbers</string>
+          <string>storage.type.puppet</string>
         </dict>
       </array>
     </dict>
   </dict>
-  <key>scopeName</key>
-  <string>source.puppet</string>
-  <key>uuid</key>
-  <string>AAF4E089-E3C9-4FB9-B099-FD2CCBD4E786</string>
 </dict>
 </plist>


### PR DESCRIPTION
This commit updates the syntax highlighting to This commit updates the syntax highlighting to glennsarti/puppet-editor-syntax@da2181a

* Fixes puppet data type highlighing being too restrictive
* Fixes inherits keyword matching beeing too overzealous
* Updates highlighting to match that used in Atom
