### PR TITLE
(maint) Add site keyword and completion tests

### DIFF
--- a/server/lib/puppet-languageserver/completion_provider.rb
+++ b/server/lib/puppet-languageserver/completion_provider.rb
@@ -10,7 +10,7 @@ module PuppetLanguageServer
         # We are in the root of the document.
 
         # Add keywords
-        keywords(%w[class define application]) { |x| items << x }
+        keywords(%w[class define application site]) { |x| items << x }
 
         # Add resources
         all_resources { |x| items << x }


### PR DESCRIPTION
Previously the site keyword was not returned as a root document keyword.  Also
this was missed due to lack of testing.  This commit adds the keyword and adds
more tests for the completion provider.
