### PR TITLE
(GH-236) Use an in memory and persistent object cache for Puppet assets

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 - ([GH-225](https://github.com/jpogran/puppet-vscode/issues/225)) Readd Local Workspace comand line option
 - ([GH-231](https://github.com/jpogran/puppet-vscode/issues/231)) Make Document Validation asynchronous
 - ([GH-236](https://github.com/jpogran/puppet-vscode/issues/236)) Remove the preload option
+- ([GH-236](https://github.com/jpogran/puppet-vscode/issues/236)) Add experimental file cache option
 
 ## 0.9.0 - 2018-02-01
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -8,6 +8,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - ([GH-225](https://github.com/jpogran/puppet-vscode/issues/225)) Readd Local Workspace comand line option
 - ([GH-231](https://github.com/jpogran/puppet-vscode/issues/231)) Make Document Validation asynchronous
+- ([GH-236](https://github.com/jpogran/puppet-vscode/issues/236)) Remove the preload option
 
 ## 0.9.0 - 2018-02-01
 

--- a/client/package.json
+++ b/client/package.json
@@ -288,6 +288,11 @@
           "default": 10,
           "description": "The timeout to connect to the local Puppet Language Server"
         },
+        "puppet.languageserver.filecache.enable": {
+          "type": "boolean",
+          "default": false,
+          "description": "(Experimental) Enable a persistent file cache for Puppet objects in the Language Server"
+        },
         "puppet.languageserver.debugFilePath": {
           "type": "string",
           "default": "",

--- a/client/package.json
+++ b/client/package.json
@@ -288,11 +288,6 @@
           "default": 10,
           "description": "The timeout to connect to the local Puppet Language Server"
         },
-        "puppet.languageserver.preLoadPuppet": {
-          "type": "boolean",
-          "default": true,
-          "description": "Initalize Puppet and Facter when local Puppet Language Server starts"
-        },
         "puppet.languageserver.debugFilePath": {
           "type": "string",
           "default": "",

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -6,11 +6,10 @@ import { IConnectionConfiguration, ConnectionType } from './interfaces';
 import { ConnectionManager } from './connection';
 
 export class ConnectionConfiguration implements IConnectionConfiguration {
-  public type: ConnectionType = ConnectionType.Unknown; 
+  public type: ConnectionType = ConnectionType.Unknown;
   public host: string = undefined;
   public port: number = undefined;
   public timeout: number = undefined;
-  public preLoadPuppet: boolean = undefined;
   public debugFilePath: string = undefined;
   public puppetAgentDir: string = undefined;
 
@@ -20,9 +19,8 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
     this.host          = config['languageserver']['address'];
     this.port          = config['languageserver']['port'];
     this.timeout       = config['languageserver']['timeout'];
-    this.preLoadPuppet = config['languageserver']['preLoadPuppet'];
     this.debugFilePath = config['languageserver']['debugFilePath'];
-    
+
     this.puppetAgentDir = config['puppetAgentDir'];
   }
 }

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -10,16 +10,18 @@ export class ConnectionConfiguration implements IConnectionConfiguration {
   public host: string = undefined;
   public port: number = undefined;
   public timeout: number = undefined;
+  public enableFileCache: boolean = undefined;
   public debugFilePath: string = undefined;
   public puppetAgentDir: string = undefined;
 
   constructor(context: vscode.ExtensionContext) {
     let config = vscode.workspace.getConfiguration('puppet');
 
-    this.host          = config['languageserver']['address'];
-    this.port          = config['languageserver']['port'];
-    this.timeout       = config['languageserver']['timeout'];
-    this.debugFilePath = config['languageserver']['debugFilePath'];
+    this.host            = config['languageserver']['address'];
+    this.port            = config['languageserver']['port'];
+    this.timeout         = config['languageserver']['timeout'];
+    this.enableFileCache = config['languageserver']['filecache']['enable'];
+    this.debugFilePath   = config['languageserver']['debugFilePath'];
 
     this.puppetAgentDir = config['puppetAgentDir'];
   }

--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -170,6 +170,9 @@ export class ConnectionManager implements IConnectionManager {
     }
     args.push('--port=' + this.connectionConfiguration.port);
     args.push('--timeout=' + this.connectionConfiguration.timeout);
+    if (this.connectionConfiguration.enableFileCache) {
+      args.push('--enable-file-cache');
+    }
     if ((this.connectionConfiguration.debugFilePath != undefined) && (this.connectionConfiguration.debugFilePath != '')) {
       args.push('--debug=' + this.connectionConfiguration.debugFilePath);
     }

--- a/client/src/connection.ts
+++ b/client/src/connection.ts
@@ -170,7 +170,6 @@ export class ConnectionManager implements IConnectionManager {
     }
     args.push('--port=' + this.connectionConfiguration.port);
     args.push('--timeout=' + this.connectionConfiguration.timeout);
-    if (this.connectionConfiguration.preLoadPuppet == false) { args.push('--no-preload'); }
     if ((this.connectionConfiguration.debugFilePath != undefined) && (this.connectionConfiguration.debugFilePath != '')) {
       args.push('--debug=' + this.connectionConfiguration.debugFilePath);
     }
@@ -291,10 +290,10 @@ export class ConnectionManager implements IConnectionManager {
 
         connectionManager.languageClient.sendRequest(messages.PuppetVersionRequest.type).then((versionDetails) => {
           lastVersionResponse = versionDetails
-          if (!connectionManager.connectionConfiguration.preLoadPuppet || (versionDetails.factsLoaded &&
+          if (versionDetails.factsLoaded &&
               versionDetails.functionsLoaded &&
               versionDetails.typesLoaded &&
-              versionDetails.classesLoaded)) {
+              versionDetails.classesLoaded) {
             clearInterval(handle);
             this.setConnectionStatus(lastVersionResponse.puppetVersion, ConnectionStatus.Running);
             resolve();

--- a/client/src/debugAdapter.ts
+++ b/client/src/debugAdapter.ts
@@ -43,6 +43,7 @@ class DebugConfiguration implements IConnectionConfiguration {
   public host: string = "127.0.0.1";
   public port: number = 8082;
   public timeout: number = 10;
+  public enableFileCache: boolean = undefined;
   public debugFilePath: string; // = "STDOUT";
   public puppetAgentDir: string;
 }

--- a/client/src/debugAdapter.ts
+++ b/client/src/debugAdapter.ts
@@ -43,7 +43,6 @@ class DebugConfiguration implements IConnectionConfiguration {
   public host: string = "127.0.0.1";
   public port: number = 8082;
   public timeout: number = 10;
-  public preLoadPuppet: boolean = false;
   public debugFilePath: string; // = "STDOUT";
   public puppetAgentDir: string;
 }
@@ -117,7 +116,7 @@ function startDebugServer(config:DebugConfiguration, debugLogger: ILogger) {
   if (localServer == null) { localServer = RubyHelper.getRubyEnvFromPuppetAgent(rubyfile, config, debugLogger); }
   // Commented out for the moment.  This will be enabled once the configuration and exact user story is figured out.
   // if (localServer == null) { localServer = RubyHelper.getRubyEnvFromPDK(rubyfile, config, debugLogger); }
-  
+
   if (localServer == null) {
     sendErrorMessage("Unable to find a valid ruby environment");
     process.exit(255);
@@ -145,7 +144,7 @@ function startDebugging(config:DebugConfiguration, debugLogger:ILogger) {
   debugServerProc.on('close', (exitCode) => {
     debugLogger.debug("Debug server terminated with exit code: " + exitCode);
     debugServerProc.kill();
-    process.exit(exitCode); 
+    process.exit(exitCode);
   });
 
   debugServerProc.on('error', (data) => {
@@ -155,19 +154,19 @@ function startDebugging(config:DebugConfiguration, debugLogger:ILogger) {
   process.on('SIGTERM', () => {
     debugLogger.debug("Received SIGTERM");
     debugServerProc.kill();
-    process.exit(0); 
+    process.exit(0);
   });
 
   process.on('SIGHUP', () => {
     debugLogger.debug("Received SIGHUP");
     debugServerProc.kill();
-    process.exit(0); 
+    process.exit(0);
   });
 
   process.on('exit', () => {
     debugLogger.debug("Received Exit");
     debugServerProc.kill();
-    process.exit(0); 
+    process.exit(0);
   });
 }
 

--- a/client/src/interfaces.ts
+++ b/client/src/interfaces.ts
@@ -21,6 +21,7 @@ export interface IConnectionConfiguration {
   host: string;
   port: number;
   timeout: number;
+  enableFileCache: boolean;
   debugFilePath: string;
   puppetAgentDir: string;
 }

--- a/client/src/interfaces.ts
+++ b/client/src/interfaces.ts
@@ -21,7 +21,6 @@ export interface IConnectionConfiguration {
   host: string;
   port: number;
   timeout: number;
-  preLoadPuppet: boolean;
   debugFilePath: string;
   puppetAgentDir: string;
 }

--- a/server/lib/puppet-languageserver.rb
+++ b/server/lib/puppet-languageserver.rb
@@ -73,6 +73,12 @@ module PuppetLanguageServer
           args[:stdio] = true
         end
 
+        opts.on('--enable-file-cache', 'Enables the file system cache for Puppet Objects (types, class etc.)') do |_misc|
+          args[:cache] = {
+            :persistent_cache => :file
+          }
+        end
+
         opts.on('--local-workspace=PATH', 'The workspace or file path that will be used to provide module-specific functionality. Default is no workspace path.') do |path|
           args[:workspace] = path
         end

--- a/server/lib/puppet-languageserver.rb
+++ b/server/lib/puppet-languageserver.rb
@@ -102,6 +102,9 @@ module PuppetLanguageServer
     log_message(:info, "Language Server is v#{PuppetVSCode.version}")
     log_message(:info, "Using Puppet v#{Puppet.version}")
 
+    log_message(:info, 'Initializing Puppet Helper Cache...')
+    PuppetLanguageServer::PuppetHelper.configure_cache(options[:cache])
+
     log_message(:info, 'Initializing settings...')
     if options[:fast_start_tcpserver]
       Thread.new do

--- a/server/lib/puppet-languageserver.rb
+++ b/server/lib/puppet-languageserver.rb
@@ -56,7 +56,8 @@ module PuppetLanguageServer
           args[:connection_timeout] = timeout.to_i
         end
 
-        opts.on('-d', '--no-preload', 'Do not preload Puppet information when the language server starts.  Default is to preload') do |_misc|
+        opts.on('-d', '--no-preload', '** DEPRECATED ** Do not preload Puppet information when the language server starts.  Default is to preload') do |_misc|
+          puts '** WARNING ** Using "--no-preload" may cause Puppet Type loading to be incomplete.'
           args[:preload_puppet] = false
         end
 
@@ -118,11 +119,11 @@ module PuppetLanguageServer
 
     log_message(:info, "Using Facter v#{Facter.version}")
     if options[:preload_puppet]
+      log_message(:info, 'Preloading Puppet Types (Sync)...')
+      PuppetLanguageServer::PuppetHelper.load_types
+
       log_message(:info, 'Preloading Facter (Async)...')
       PuppetLanguageServer::FacterHelper.load_facts_async
-
-      log_message(:info, 'Preloading Puppet Types (Async)...')
-      PuppetLanguageServer::PuppetHelper.load_types_async
 
       log_message(:info, 'Preloading Functions (Async)...')
       PuppetLanguageServer::PuppetHelper.load_functions_async

--- a/server/lib/puppet-languageserver/definition_provider.rb
+++ b/server/lib/puppet-languageserver/definition_provider.rb
@@ -65,14 +65,14 @@ module PuppetLanguageServer
     def self.type_or_class(resource_name)
       # Strip the leading double-colons for root resource names
       resource_name = resource_name.slice(2, resource_name.length - 2) if resource_name.start_with?('::')
-      location = PuppetLanguageServer::PuppetHelper.type_load_info(resource_name)
-      location = PuppetLanguageServer::PuppetHelper.class_load_info(resource_name) if location.nil?
-      unless location.nil?
+      item = PuppetLanguageServer::PuppetHelper.get_type(resource_name)
+      item = PuppetLanguageServer::PuppetHelper.get_class(resource_name) if item.nil?
+      unless item.nil?
         return LanguageServer::Location.create(
-          'uri' => 'file:///' + location['source'],
-          'fromline' => location['line'],
+          'uri' => 'file:///' + item.source,
+          'fromline' => item.line,
           'fromchar' => 0,
-          'toline' => location['line'],
+          'toline' => item.line,
           'tochar' => 1024
         )
       end
@@ -81,17 +81,15 @@ module PuppetLanguageServer
     private_class_method :type_or_class
 
     def self.function_name(func_name)
-      location = PuppetLanguageServer::PuppetHelper.function_load_info(func_name)
-      unless location.nil?
-        return LanguageServer::Location.create(
-          'uri' => 'file:///' + location['source'],
-          'fromline' => location['line'],
-          'fromchar' => 0,
-          'toline' => location['line'],
-          'tochar' => 1024
-        )
-      end
-      nil
+      item = PuppetLanguageServer::PuppetHelper.function(func_name)
+      return nil if item.nil? || item.source.nil? || item.line.nil?
+      LanguageServer::Location.create(
+        'uri' => 'file:///' + item.source,
+        'fromline' => item.line,
+        'fromchar' => 0,
+        'toline' => item.line,
+        'tochar' => 1024
+      )
     end
     private_class_method :function_name
   end

--- a/server/lib/puppet-languageserver/hover_provider.rb
+++ b/server/lib/puppet-languageserver/hover_provider.rb
@@ -40,10 +40,10 @@ module PuppetLanguageServer
         item_type = PuppetLanguageServer::PuppetHelper.get_type(path[distance_up_ast - 1].type_name.value)
         raise "#{path[distance_up_ast - 1].type_name.value} is not a valid puppet type" if item_type.nil?
         # Check if it's a property
-        attribute = item_type.validproperty?(item.attribute_name)
+        attribute = item_type.properties.keys.include?(item.attribute_name.intern)
         if attribute != false
           content = get_attribute_property_content(item_type, item.attribute_name.intern)
-        elsif item_type.validparameter?(item.attribute_name.intern)
+        elsif item_type.parameters.keys.include?(item.attribute_name.intern)
           content = get_attribute_parameter_content(item_type, item.attribute_name.intern)
         end
 
@@ -102,17 +102,17 @@ module PuppetLanguageServer
     end
 
     def self.get_attribute_parameter_content(item_type, param)
-      param_type = item_type.attrclass(param)
+      param_type = item_type.parameters[param]
       content = "**#{param}** Parameter"
-      content += "\n\n#{param_type.doc}" unless param_type.doc.nil?
+      content += "\n\n#{param_type[:doc]}" unless param_type[:doc].nil?
       content
     end
 
     def self.get_attribute_property_content(item_type, property)
-      prop_type = item_type.attrclass(property)
+      prop_type = item_type.properties[property]
       content = "**#{property}** Property"
-      content += "\n\n(_required_)" if prop_type.required?
-      content += "\n\n#{prop_type.doc}" unless prop_type.doc.nil?
+      content += "\n\n(_required_)" if prop_type[:required?]
+      content += "\n\n#{prop_type[:doc]}" unless prop_type[:doc].nil?
       content
     end
 
@@ -124,7 +124,7 @@ module PuppetLanguageServer
 
       # TODO: what about rvalue?
       content = "**#{func_name}** Function\n\n" # TODO: Do I add in the params from the arity number?
-      content += func_info[:doc]
+      content += func_info.doc
 
       content
     end

--- a/server/lib/puppet-languageserver/puppet_helper.rb
+++ b/server/lib/puppet-languageserver/puppet_helper.rb
@@ -1,12 +1,12 @@
 require 'puppet/indirector/face'
 require 'pathname'
 
-%w[puppet_helper/faux_objects puppet_helper/cache].each do |lib|
- begin
-   require "puppet-languageserver/#{lib}"
- rescue LoadError
-   require File.expand_path(File.join(File.dirname(__FILE__), lib))
- end
+%w[puppet_helper/faux_objects puppet_helper/cache puppet_helper/file_cache].each do |lib|
+  begin
+    require "puppet-languageserver/#{lib}"
+  rescue LoadError
+    require File.expand_path(File.join(File.dirname(__FILE__), lib))
+  end
 end
 
 module PuppetLanguageServer

--- a/server/lib/puppet-languageserver/puppet_helper/cache.rb
+++ b/server/lib/puppet-languageserver/puppet_helper/cache.rb
@@ -25,7 +25,14 @@ module PuppetLanguageServer
       end
 
       def configure_persistent_cache(options = {})
-        @persistent_cache = nil
+        options = {} if options.nil?
+        # Configure the persistent cache if specified
+        case options[:persistent_cache]
+        when :file
+          @persistent_cache = PuppetLanguageServer::PuppetHelper::PersistentFileCache.new(options[:persistent_cache_options])
+        else
+          @persistent_cache = nil
+        end
         true
       end
 

--- a/server/lib/puppet-languageserver/puppet_helper/cache.rb
+++ b/server/lib/puppet-languageserver/puppet_helper/cache.rb
@@ -1,0 +1,155 @@
+module PuppetLanguageServer
+  module PuppetHelper
+    class Cache
+      def initialize(options = {})
+        @cache_lock = Mutex.new
+        @inmemory_cache = []
+        @persistent_cache = nil
+
+        # The cache consists of an array of hashes
+        # [ {
+        #     :file_key => <Unique name of the file>
+        #     :section  => <Type of object in the file :function, :type, :class>
+        #     :data     => {
+        #                    :name => <Name of the object>
+        #                    :data => <Object Data>
+        #                  }
+        #   },
+        #  ...
+        # ]
+
+        # Note this cache is not persistent, i.e. once this object is disposed, the cache
+        # must be rebuilt.  However this class could use a persistent backing store,
+        # such as the filesystem to read cache objects from
+        configure_persistent_cache(options)
+      end
+
+      def configure_persistent_cache(options = {})
+        @persistent_cache = nil
+        true
+      end
+
+      def exist?(absolute_path, section = nil)
+        return false if absolute_path.nil?
+        file_key = canonical_path(absolute_path)
+
+        idx = @inmemory_cache.find_index do |item|
+          item[:file_key] == file_key &&
+            (section.nil? || item[:section] == section) &&
+            !item[:data].nil?
+        end
+
+        !idx.nil?
+      end
+
+      def load_from_persistent_cache!(absolute_path)
+        return false if @persistent_cache.nil?
+        file_key = canonical_path(absolute_path)
+
+        json_obj = @persistent_cache.load(absolute_path, file_key)
+        return false if json_obj.nil?
+
+        @cache_lock.synchronize do
+          # Clear out any existing info
+          @inmemory_cache.reject! { |item| item[:file_key] == file_key }
+          # Get the json object from the persistent cache
+          # Build up the new cache entries
+          result = json_obj['content'].map do |entry|
+            new_entry = {
+              :file_key => entry['file_key'],
+              :section  => entry['section'].intern,
+              :data     => {}
+            }
+            entry['data'].each do |name, dataitem|
+              case new_entry[:section]
+              when :function
+                new_entry[:data][name.intern] = PuppetLanguageServer::PuppetHelper::FauxFunction.json_create(dataitem)
+              when :type
+                new_entry[:data][name.intern] = PuppetLanguageServer::PuppetHelper::FauxType.json_create(dataitem)
+              when :class
+                new_entry[:data][name.intern] = PuppetLanguageServer::PuppetHelper::FauxPuppetClass.json_create(dataitem)
+              end
+            end
+
+            new_entry
+          end
+          @inmemory_cache.concat(result)
+        end
+        true
+      end
+
+      def set(absolute_path, section, object)
+        file_key = canonical_path(absolute_path)
+        object = {} if object.nil?
+
+        @cache_lock.synchronize do
+          idx = @inmemory_cache.find_index { |item| item[:file_key] == file_key && item[:section] == section }
+          if idx.nil?
+            @inmemory_cache << { :file_key => file_key, :section => section, :data => object }
+          else
+            item = @inmemory_cache[idx]
+            item[:data] = object
+          end
+        end
+
+        if @persistent_cache.nil?
+          true
+        else
+          content = {
+            'metadata' => {},
+            'content'  => @inmemory_cache.select { |item| item[:file_key] == file_key }
+          }
+          @persistent_cache.save!(absolute_path, content)
+        end
+      end
+
+      def get(absolute_path, section)
+        file_key = canonical_path(absolute_path)
+        @inmemory_cache.each do |item|
+          next unless item[:file_key] == file_key && item[:section] == section
+          return item[:data]
+        end
+        nil
+      end
+
+      def object_by_name(section, name)
+        name = name.intern if name.is_a?(String)
+        @inmemory_cache.each do |item|
+          next unless item[:section] == section
+          next if item[:data].nil? || item[:data].empty?
+          return item[:data][name] unless item[:data][name].nil?
+        end
+        nil
+      end
+
+      def object_names_by_section(section)
+        result = []
+        @inmemory_cache.each do |item|
+          next unless item[:section] == section
+          next if item[:data].nil? || item[:data].empty?
+          result += item[:data].keys
+        end
+        result.uniq!
+        result.compact
+      end
+
+      def objects_by_section(section, &_block)
+        @inmemory_cache.each do |item|
+          next unless item[:section] == section
+          next if item[:data].nil? || item[:data].empty?
+          item[:data].each { |name, data| yield name, data }
+        end
+      end
+
+      private
+
+      def canonical_path(filepath)
+        # Strictly speaking some file systems are case sensitive but ruby/puppet throws a fit
+        # with naming if you do
+        file_key = filepath.downcase
+
+        file_key
+      end
+    end
+  end
+end

--- a/server/lib/puppet-languageserver/puppet_helper/faux_objects.rb
+++ b/server/lib/puppet-languageserver/puppet_helper/faux_objects.rb
@@ -1,0 +1,195 @@
+module PuppetLanguageServer
+  module PuppetHelper
+    # key            => Unique name of the object
+    # calling_source => The file that was invoked to create the object
+    # source         => The file that _actually_ created the object
+    # line           => The line number in the source file where the object was created
+    # char           => The character number in the source file where the object was created
+    # length         => The length of characters from `char` in the source file where the object was created
+    class FauxBaseObject
+      attr_accessor :key
+      attr_accessor :calling_source
+      attr_accessor :source
+      attr_accessor :line
+      attr_accessor :char
+      attr_accessor :length
+
+      def from_puppet!(*)
+        raise NotImplmentedError
+      end
+
+      def to_json(*)
+        raise NotImplmentedError
+      end
+
+      def self.json_create(*)
+        raise NotImplmentedError
+      end
+    end
+
+    class FauxFunction < FauxBaseObject
+      attr_accessor :doc
+      attr_accessor :arity
+      attr_accessor :type
+
+      def from_puppet!(name, item)
+        self.key            = name
+        self.source         = item[:source_location][:source]
+        self.calling_source = source
+        self.line           = item[:source_location][:line]
+        # TODO: name ?
+        self.doc   = item[:doc]
+        self.arity = item[:arity]
+        self.type  = item[:type]
+      end
+
+      def to_json(*options)
+        {
+          'key'            => key,
+          'calling_source' => calling_source,
+          'source'         => source,
+          'line'           => line,
+          'char'           => char,
+          'length'         => length,
+
+          'doc'            => doc,
+          'arity'          => arity,
+          'type'           => type
+        }.to_json(*options)
+      end
+
+      def self.json_create(obj)
+        result = new
+
+        result.key            = obj['key'].intern
+        result.calling_source = obj['calling_source']
+        result.source         = obj['source']
+        result.line           = obj['line']
+        result.char           = obj['char']
+        result.length         = obj['length']
+
+        result.doc = obj['doc']
+        result.arity = obj['arity']
+        result.type = obj['type'].intern
+
+        result
+      end
+    end
+
+    class FauxType < FauxBaseObject
+      attr_accessor :doc
+      attr_accessor :attributes
+
+      def allattrs
+        @attributes.keys
+      end
+
+      def parameters
+        @attributes.select { |_name, data| data[:type] == :param }
+      end
+
+      def properties
+        @attributes.select { |_name, data| data[:type] == :property }
+      end
+
+      def meta_parameters
+        @attributes.select { |_name, data| data[:type] == :meta }
+      end
+
+      def from_puppet!(name, item)
+        name = name.intern if name.is_a?(String)
+        self.key            = name
+        self.source         = item._source_location[:source]
+        self.calling_source = source
+        self.line           = item._source_location[:line]
+        self.doc            = item.doc
+
+        self.attributes = {}
+        item.allattrs.each do |attrname|
+          attrclass = item.attrclass(attrname)
+          val = {
+            :type => item.attrtype(attrname),
+            :doc  => attrclass.doc
+          }
+          val[:required?] = attrclass.required? if attrclass.respond_to?(:required?)
+          attributes[attrname] = val
+        end
+      end
+
+      def to_json(*options)
+        {
+          'key'            => key,
+          'calling_source' => calling_source,
+          'source'         => source,
+          'line'           => line,
+          'char'           => char,
+          'length'         => length,
+
+          'doc'            => doc,
+          'attributes'     => attributes
+        }.to_json(*options)
+      end
+
+      def self.json_create(obj)
+        result = new
+
+        result.key            = obj['key'].intern
+        result.calling_source = obj['calling_source']
+        result.source         = obj['source']
+        result.line           = obj['line']
+        result.char           = obj['char']
+        result.length         = obj['length']
+
+        result.doc = obj['doc']
+        result.attributes = {}
+        unless obj['attributes'].nil?
+          obj['attributes'].each do |attr_name, obj_attr|
+            result.attributes[attr_name.intern] = {
+              :type      => obj_attr['type'].intern,
+              :doc       => obj_attr['doc'],
+              :required? => obj_attr['required?']
+            }
+          end
+        end
+
+        result
+      end
+    end
+
+    class FauxPuppetClass < FauxBaseObject
+      def from_puppet!(name, item)
+        self.key            = name
+        self.source         = item['source']
+        self.calling_source = source
+        self.line           = item['line']
+        self.char           = item['char']
+
+        # TODO: Doc, parameters?
+      end
+
+      def to_json(*options)
+        {
+          'key'            => key,
+          'calling_source' => calling_source,
+          'source'         => source,
+          'line'           => line,
+          'char'           => char,
+          'length'         => length
+        }.to_json(*options)
+      end
+
+      def self.json_create(obj)
+        result = new
+
+        result.key            = obj['key'].intern
+        result.calling_source = obj['calling_source']
+        result.source         = obj['source']
+        result.line           = obj['line']
+        result.char           = obj['char']
+        result.length         = obj['length']
+
+        result
+      end
+    end
+  end
+end

--- a/server/lib/puppet-languageserver/puppet_helper/file_cache.rb
+++ b/server/lib/puppet-languageserver/puppet_helper/file_cache.rb
@@ -1,0 +1,83 @@
+module PuppetLanguageServer
+  module PuppetHelper
+    class PersistentFileCache
+      attr_reader :cache_dir
+
+      def initialize(_inmemory_cache, _options = {})
+        require 'digest'
+        require 'json'
+
+        @cache_dir = File.join(ENV['TMP'], 'puppet-vscode-cache')
+        Dir.mkdir(@cache_dir) unless Dir.exist?(@cache_dir)
+      end
+
+      def load(absolute_path, file_key)
+        cache_file = File.join(cache_dir, cache_filename(file_key))
+
+        content = read_cache_file(cache_file)
+        return nil if content.nil?
+
+        json_obj = JSON.parse(content)
+
+        # Check that this is from the same language server version
+        unless json_obj.nil? || json_obj['metadata']['version'] == PuppetVSCode.version
+          PuppetLanguageServer.log_message(:debug, "[PuppetHelperFileCache::load_from_persistent_cache] Error loading #{absolute_path}: Expected language server version #{PuppetVSCode.version} but found #{json_obj['metadata']['version']}")
+          json_obj = nil
+        end
+        # Check that the source file hash matches
+        content_hash = calculate_hash(absolute_path) unless json_obj.nil?
+        if json_obj.nil? || json_obj['metadata']['content_hash'] != content_hash
+          PuppetLanguageServer.log_message(:debug, "[PuppetHelperFileCache::load_from_persistent_cache] Error loading #{absolute_path}: Expected content_hash of #{content_hash} but found #{json_obj['metadata']['content_hash']}")
+          json_obj = nil
+        else
+          PuppetLanguageServer.log_message(:debug, "[PuppetHelperFileCache::load_from_persistent_cache] Loading #{absolute_path} from cache")
+        end
+
+        json_obj
+      rescue RuntimeError => detail
+        PuppetLanguageServer.log_message(:debug, "[PuppetHelperFileCache::load_from_persistent_cache] Error loading #{absolute_path}: #{detail}")
+        raise
+      end
+
+      def save!(absolute_path, content)
+        file_key = canonical_path(absolute_path)
+        cache_file = File.join(cache_dir, cache_filename(file_key))
+
+        # Inject metadata
+        content['metadata']['version'] = PuppetVSCode.version
+        content['metadata']['content_hash'] = calculate_hash(absolute_path)
+
+        save_cache_file(cache_file, content.to_json)
+      end
+
+      private
+
+      def save_cache_file(filepath, content)
+        File.open(filepath, 'wb') { |file| file.write(content) }
+        true
+      end
+
+      def read_cache_file(filepath)
+        return nil unless File.exist?(filepath)
+
+        File.open(filepath, 'rb') { |file| file.read }
+      end
+
+      def cache_filename(absolute_path)
+        Digest::SHA256.hexdigest(canonical_path(absolute_path)) + '.txt'
+      end
+
+      def calculate_hash(filepath)
+        Digest::SHA256.hexdigest(read_cache_file(filepath))
+      end
+
+      def canonical_path(filepath)
+        # Strictly speaking some file systems are case sensitive but ruby/puppet throws a fit
+        # with naming if you do
+        file_key = filepath.downcase
+
+        file_key
+      end
+    end
+  end
+end

--- a/server/spec/languageserver/integration/puppet-languageserver/completion_provider_spec.rb
+++ b/server/spec/languageserver/integration/puppet-languageserver/completion_provider_spec.rb
@@ -8,6 +8,10 @@ describe 'completion_provider' do
   let(:subject) { PuppetLanguageServer::CompletionProvider }
   let(:nil_response) { LanguageServer::CompletionList.create_nil_response }
 
+  before(:all) do
+    wait_for_puppet_loading
+  end
+
   describe '#complete' do
     describe "Given an incomplete manifest which has syntax errors" do
       it "should raise an error" do

--- a/server/spec/languageserver/integration/puppet-languageserver/definition_provider_spec.rb
+++ b/server/spec/languageserver/integration/puppet-languageserver/definition_provider_spec.rb
@@ -19,14 +19,7 @@ describe 'definition_provider' do
 
   describe '#find_defintion' do
     before(:all) do
-      # Ensure the functions are loaded so that defintion information is available
-      PuppetLanguageServer::PuppetHelper.load_functions unless PuppetLanguageServer::PuppetHelper.functions_loaded?
-
-      # Ensure the types are loaded so that defintion information is available
-      PuppetLanguageServer::PuppetHelper.load_types unless PuppetLanguageServer::PuppetHelper.types_loaded?
-
-      # Ensure the classes are loaded so that defintion information is available
-      PuppetLanguageServer::PuppetHelper.load_classes unless PuppetLanguageServer::PuppetHelper.classes_loaded?
+      wait_for_puppet_loading
     end
 
     context 'When cursor is on a function name' do

--- a/server/spec/languageserver/integration/puppet-languageserver/hover_provider_spec.rb
+++ b/server/spec/languageserver/integration/puppet-languageserver/hover_provider_spec.rb
@@ -4,6 +4,10 @@ describe 'hover_provider' do
   let(:subject) { PuppetLanguageServer::HoverProvider }
   let(:nil_response) { LanguageServer::Hover.create_nil_response }
 
+  before(:all) do
+    wait_for_puppet_loading
+  end
+
   describe '#resolve' do
     let(:content) { <<-EOT
 user { 'Bob':
@@ -187,7 +191,7 @@ EOT
         let(:line_num) { 2 }
         let(:char_num) { 5 }
 
-        it 'should return property description' do
+        it 'should return parameter description' do
           result = subject.resolve(content, line_num, char_num)
 
           expect(result['contents']).to start_with("**name** Parameter\n")
@@ -198,7 +202,7 @@ EOT
         let(:line_num) { 2 }
         let(:char_num) { 10 }
 
-        it 'should return property description' do
+        it 'should return parameter description' do
           result = subject.resolve(content, line_num, char_num)
 
           expect(result['contents']).to start_with("**name** Parameter\n")

--- a/server/spec/languageserver/integration/puppet-languageserver/puppet_helper_spec.rb
+++ b/server/spec/languageserver/integration/puppet-languageserver/puppet_helper_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 describe 'puppet_helper' do
   let(:subject) { PuppetLanguageServer::PuppetHelper }
 
+  before(:all) do
+    wait_for_puppet_loading
+  end
+
   # The concat function is loaded from the fixtures/cache/lib/puppet/parser/functions/concat.rb file
   # The bad_function function is loaded from the fixtures/cache/lib/puppet/parser/functions/badfunction.rb file
   # The bad_file function is loaded from the fixtures/cache/lib/puppet/parser/functions/badfile.rb file
@@ -27,14 +31,14 @@ describe 'puppet_helper' do
     it 'should get details about functions which do not error' do
       result = subject.function(good_function)
 
-      expect(result).to include(:name)
-      expect(result).to include(:type)
+      expect(result.doc).to_not be_nil
+      expect(result.type).to_not be_nil
     end
     it 'should get details about functions which error inside the function code' do
       result = subject.function(bad_function)
 
-      expect(result).to include(:name)
-      expect(result).to include(:type)
+      expect(result.doc).to_not be_nil
+      expect(result.type).to_not be_nil
     end
     it 'should not get details about functions which error during loading' do
       result = subject.function(unloadable_function)

--- a/server/spec/languageserver/unit/puppet-languageserver/puppet_helper/cache_spec.rb
+++ b/server/spec/languageserver/unit/puppet-languageserver/puppet_helper/cache_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+describe 'PuppetLanguageServer::PuppetHelper::Cache' do
+  let(:new_filename) { 'new_filename' }
+  let(:new_section) { :type }
+
+  let(:filename_existing) { 'abc123' }
+  let(:section_existing) { :function }
+  let(:object_existing1) { {:func1 => 'func1', :func2 => 'func2' } }
+  let(:object_existing2) { {:func3 => 'func3', :func4 => 'func4' } }
+
+  let(:subject) {
+    obj = PuppetLanguageServer::PuppetHelper::Cache.new()
+    obj.set(filename_existing, section_existing, object_existing1)
+    obj.set('second_file', section_existing, object_existing2)
+    obj
+  }
+
+  describe '#exist?' do
+    it 'should return true for a file that exists in the cache' do
+      expect(subject.exist?('abc123')).to be true
+    end
+
+    it 'should return true for a file that exists in the cache (case insensitive)' do
+      expect(subject.exist?('aBc123')).to be true
+    end
+
+    it 'should return false for a file that exists in the cache' do
+      expect(subject.exist?('does_not_exist')).to be false
+    end
+
+    it 'should return true for a file and section that exists in the cache' do
+      expect(subject.exist?('abc123', :function)).to be true
+    end
+
+    it 'should return true for a file and section that exists in the cache (case insensitive)' do
+      expect(subject.exist?('abC123', :function)).to be true
+    end
+
+    it 'should return false for a file that exists, but not the section, in the cache' do
+      expect(subject.exist?('abc123', :doesnotexist)).to be false
+    end
+  end
+
+  describe '#set' do
+    before(:each) do
+      # Arrange
+      expect(subject.exist?(filename_existing)).to be true
+      expect(subject.exist?(filename_existing, section_existing)).to be true
+      expect(subject.exist?(new_filename)).to be false
+    end
+
+    it 'should add new filenames' do
+      # Act
+      expect(subject.set(new_filename, new_section, {})).to be true
+      # Assert
+      expect(subject.exist?(new_filename)).to be true
+      expect(subject.exist?(new_filename, new_section)).to be true
+    end
+
+    it 'should add new sections to existing filenames' do
+      # Arrange
+      expect(subject.exist?(filename_existing, new_section)).to be false
+      # Act
+      expect(subject.set(filename_existing, new_section, {})).to be true
+      # Assert
+      expect(subject.exist?(filename_existing)).to be true
+      expect(subject.exist?(filename_existing, section_existing)).to be true
+      expect(subject.exist?(filename_existing, new_section)).to be true
+    end
+
+    it 'should overwrite sections in existing filenames' do
+      # Arrange
+      old_object = subject.get(filename_existing, section_existing)
+      new_object = { :something => 'new'}
+      # Act
+      expect(subject.set(filename_existing, section_existing, new_object)).to be true
+      # Assert
+      expect(subject.get(filename_existing, section_existing)).to eq(new_object)
+    end
+  end
+
+  describe '#get' do
+    before(:each) do
+      # Arrange
+      expect(subject.exist?(filename_existing)).to be true
+      expect(subject.exist?(filename_existing, section_existing)).to be true
+    end
+
+    it 'should get existing items from the cache' do
+      expect(subject.get(filename_existing, section_existing)).to eq(object_existing1)
+    end
+
+    it 'should return nil for objects that do not exist' do
+      expect(subject.get('does_not_exist', section_existing)).to be_nil
+      expect(subject.get('does_not_exist', :doesnotexist)).to be_nil
+    end
+  end
+
+  describe '#object_by_name' do
+    it 'should get existing items from the cache' do
+      expect(subject.object_by_name(section_existing, :func1)).to eq('func1')
+    end
+
+    it 'should return nil for objects that do not exist' do
+      expect(subject.object_by_name(:doesnotexist, :func1)).to be_nil
+      expect(subject.object_by_name(section_existing, :doesnotexist)).to be_nil
+    end
+  end
+
+
+  describe '#object_names_by_section' do
+    it 'should get existing items from the cache' do
+      expect(subject.object_names_by_section(section_existing)).to eq([:func1, :func2, :func3, :func4])
+    end
+
+    it 'should return empty array for objects that do not exist' do
+      expect(subject.object_names_by_section(:doesnotexist)).to eq([])
+    end
+  end
+
+  describe '#objects_by_section' do
+    it 'should get existing items from the cache' do
+      result = []
+      subject.objects_by_section(section_existing) { |_name, obj| result << obj }
+      expect(result).to eq(['func1', 'func2', 'func3', 'func4'])
+    end
+
+    it 'should not yield for that do not exist' do
+      result = []
+      subject.objects_by_section(:doesnotexist) { |_name, obj| result << obj }
+      expect(result).to eq([])
+    end
+  end
+end

--- a/server/spec/languageserver/unit/puppet-languageserver/puppet_helper/faux_objects_spec.rb
+++ b/server/spec/languageserver/unit/puppet-languageserver/puppet_helper/faux_objects_spec.rb
@@ -1,0 +1,208 @@
+require 'spec_helper'
+
+describe 'PuppetLanguageServer::PuppetHelper::FauxObjects' do
+
+  shared_examples_for 'a base Faux object' do
+    [:key, :calling_source, :source, :line, :char, :length, :from_puppet!, :to_json].each do |testcase|
+      it "instance should respond to #{testcase}" do
+        expect(subject).to respond_to(testcase)
+      end
+    end
+
+    [:json_create].each do |testcase|
+      it "class should respond to #{testcase}" do
+        expect(subject.class).to respond_to(testcase)
+      end
+    end
+
+  end
+
+  describe 'FauxFunction' do
+    let(:subject) { PuppetLanguageServer::PuppetHelper::FauxFunction.new }
+
+    let(:puppet_funcname) { :rspec_function }
+    let(:puppet_func) {
+      {
+        :doc             => 'function documentation',
+        :arity           => 0,
+        :type            => :statement,
+        :source_location => {
+          :source => 'source',
+          :line   => 1,
+        }
+      }
+    }
+
+    it_should_behave_like 'a base Faux object'
+
+    [:doc, :arity, :type].each do |testcase|
+      it "instance should respond to #{testcase}" do
+        expect(subject).to respond_to(testcase)
+      end
+    end
+
+    describe '#from_puppet!' do
+      it 'should populate from a Puppet function object' do
+        subject.from_puppet!(puppet_funcname, puppet_func)
+
+        expect(subject.key).to eq(puppet_funcname)
+        expect(subject.source).to_not be_nil
+        expect(subject.calling_source).to_not be_nil
+        expect(subject.line).to_not be_nil
+        expect(subject.doc).to_not be_nil
+        expect(subject.arity).to_not be_nil
+        expect(subject.type).to_not be_nil
+      end
+    end
+
+    describe '#to_json' do
+      it 'should serialize to json' do
+        subject.from_puppet!(puppet_funcname, puppet_func)
+        serial = subject.to_json
+
+        expect(serial).to be_a(String)
+      end
+    end
+
+    describe '#json_create' do
+      it 'should deserialize FauxFunction' do
+        subject.from_puppet!(puppet_funcname, puppet_func)
+        serial = subject.to_json
+        deserial = PuppetLanguageServer::PuppetHelper::FauxFunction.json_create(JSON.parse(serial))
+
+        expect(deserial).to be_a(PuppetLanguageServer::PuppetHelper::FauxFunction)
+      end
+
+      [:key, :calling_source, :source, :line, :char, :length, :doc, :arity, :type].each do |testcase|
+        it "should deserialize a serialized #{testcase} value" do
+          subject.from_puppet!(puppet_funcname, puppet_func)
+          serial = subject.to_json
+          deserial = PuppetLanguageServer::PuppetHelper::FauxFunction.json_create(JSON.parse(serial))
+
+          expect(deserial.send(testcase)).to eq(subject.send(testcase))
+        end
+      end
+    end
+  end
+
+  describe 'FauxType' do
+    let(:subject) { PuppetLanguageServer::PuppetHelper::FauxType.new }
+
+    let(:puppet_typename) { :rspec_class }
+    let(:puppet_type) {
+      # Get a real puppet type
+      Puppet::Type.type(:user)
+    }
+
+    it_should_behave_like 'a base Faux object'
+
+    [:doc, :attributes, :allattrs, :parameters, :properties, :meta_parameters].each do |testcase|
+      it "instance should respond to #{testcase}" do
+        expect(subject).to respond_to(testcase)
+      end
+    end
+
+    describe '#from_puppet!' do
+      it 'should populate from a Puppet class object' do
+        subject.from_puppet!(puppet_typename, puppet_type)
+
+        expect(subject.key).to eq(puppet_typename)
+        expect(subject.source).to_not be_nil
+        expect(subject.calling_source).to_not be_nil
+        expect(subject.line).to_not be_nil
+      end
+    end
+
+    describe '#to_json' do
+      it 'should serialize to json' do
+        subject.from_puppet!(puppet_typename, puppet_type)
+        serial = subject.to_json
+
+        expect(serial).to be_a(String)
+      end
+    end
+
+    describe '#json_create' do
+      it 'should deserialize FauxType' do
+        subject.from_puppet!(puppet_typename, puppet_type)
+        serial = subject.to_json
+        deserial = PuppetLanguageServer::PuppetHelper::FauxType.json_create(JSON.parse(serial))
+
+        expect(deserial).to be_a(PuppetLanguageServer::PuppetHelper::FauxType)
+      end
+
+      [:doc, :attributes, :allattrs, :parameters, :properties, :meta_parameters, :key, :calling_source, :source, :line, :char, :length].each do |testcase|
+        it "should deserialize a serialized #{testcase} value" do
+          subject.from_puppet!(puppet_typename, puppet_type)
+          serial = subject.to_json
+          deserial = PuppetLanguageServer::PuppetHelper::FauxType.json_create(JSON.parse(serial))
+
+          expect(deserial.send(testcase)).to eq(subject.send(testcase))
+        end
+      end
+    end
+  end
+
+  describe 'FauxPuppetClass' do
+    let(:subject) { PuppetLanguageServer::PuppetHelper::FauxPuppetClass.new }
+
+    let(:puppet_classname) { :rspec_class }
+    let(:puppet_class) {
+      {
+        'source' => 'source',
+        'line'   => 1,
+        'char'   => 1,
+      }
+    }
+
+    it_should_behave_like 'a base Faux object'
+
+    # No additional methods to test
+    # [:doc].each do |testcase|
+    #   it "instance should respond to #{testcase}" do
+    #     expect(subject).to respond_to(testcase)
+    #   end
+    # end
+
+    describe '#from_puppet!' do
+      it 'should populate from a Puppet class object' do
+        subject.from_puppet!(puppet_classname, puppet_class)
+
+        expect(subject.key).to eq(puppet_classname)
+        expect(subject.source).to_not be_nil
+        expect(subject.calling_source).to_not be_nil
+        expect(subject.line).to_not be_nil
+        expect(subject.char).to_not be_nil
+      end
+    end
+
+    describe '#to_json' do
+      it 'should serialize to json' do
+        subject.from_puppet!(puppet_classname, puppet_class)
+        serial = subject.to_json
+
+        expect(serial).to be_a(String)
+      end
+    end
+
+    describe '#json_create' do
+      it 'should deserialize FauxFunction' do
+        subject.from_puppet!(puppet_classname, puppet_class)
+        serial = subject.to_json
+        deserial = PuppetLanguageServer::PuppetHelper::FauxPuppetClass.json_create(JSON.parse(serial))
+
+        expect(deserial).to be_a(PuppetLanguageServer::PuppetHelper::FauxPuppetClass)
+      end
+
+      [:key, :calling_source, :source, :line, :char, :length].each do |testcase|
+        it "should deserialize a serialized #{testcase} value" do
+          subject.from_puppet!(puppet_classname, puppet_class)
+          serial = subject.to_json
+          deserial = PuppetLanguageServer::PuppetHelper::FauxPuppetClass.json_create(JSON.parse(serial))
+
+          expect(deserial.send(testcase)).to eq(subject.send(testcase))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously all Puppet assets (function metdatam type metdata) was loaded directly from Puppet on every start of the Language Server.  To help with load times and reduce memory foot print;

* Adds fake/faux Puppet objects which will be populated from Puppet and be consumed by the language server
* Adds an object cache to hold the fake objects
* Adds an experimental persistence layer for the cached objects to speed up load time.