### PR TITLE
(WIP)(maint) Fix build errors

### DIFF
--- a/client/src/providers/previewNodeGraphProvider.ts
+++ b/client/src/providers/previewNodeGraphProvider.ts
@@ -7,7 +7,7 @@ import { ConnectionStatus } from '../interfaces';
 import { IConnectionManager } from '../connection';
 import { reporter } from '../telemetry/telemetry';
 import * as messages from '../messages';
-import * as viz from 'viz.js';
+import * as viz from 'viz.js/viz.js';
 
 export function isNodeGraphFile(document: vscode.TextDocument) {
   return document.languageId === 'puppet'

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -7,7 +7,7 @@
     "es6"
   ],
   "sourceMap": true,
-  "rootDir": "."
+  "rootDir": "src"
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This commit updates tsconfig.json to point to the src folder and not the root directory. It also points the module import for viz.js to the file instead of folder to avoid build errors