### PR TITLE
Update puppet lint - 2.3.5

### DIFF
--- a/server/Rakefile
+++ b/server/Rakefile
@@ -48,8 +48,11 @@ task :gem_revendor do
   # Clean out the vendor directory first
   puts "Clearing the vendor directory..."
   vendor_dir = File.join(File.dirname(__FILE__),'vendor')
-  FileUtils.rm_rf(vendor_dir) if Dir.exists?(vendor_dir)
-  Dir.mkdir(vendor_dir)
+  gem_list.each do |vendor|
+    gem_dir = File.join(vendor_dir,vendor[:directory])
+    FileUtils.rm_rf(gem_dir) if Dir.exists?(gem_dir)
+  end
+  Dir.mkdir(vendor_dir) unless Dir.exists?(vendor_dir)
 
   gem_list.each do |vendor|
     puts "Vendoring #{vendor[:directory]}..."
@@ -82,7 +85,7 @@ Gem List
 --------
 
 HEREDOC
-  gem_list.each { |vendor| readme += "* #{vendor[:directory]} (#{vendor[:github_repo]} ref #{vendor[:github_ref]})"}
+  gem_list.each { |vendor| readme += "* #{vendor[:directory]} (#{vendor[:github_repo]} ref #{vendor[:github_ref]})\n"}
   File.open(File.join(vendor_dir,'README.md'), 'wb') { |file| file.write(readme + "\n") }
 end
 

--- a/server/Rakefile
+++ b/server/Rakefile
@@ -41,7 +41,7 @@ task :gem_revendor do
     {
       :directory => 'puppet-lint',
       :github_repo => 'https://github.com/rodjek/puppet-lint.git',
-      :github_ref => '2.3.3',
+      :github_ref => '2.3.5',
     }
   ]
 

--- a/server/spec/languageserver/fixtures/manifest_with_lint_errors.pp
+++ b/server/spec/languageserver/fixtures/manifest_with_lint_errors.pp
@@ -1,0 +1,50 @@
+#
+class example_manifest_with_multiple_lint_errors
+{
+
+  # --------------------------------------------------------------------
+  # Set cipher suites order as secure as possible (Enables Perfect Forward Secrecy)
+  # Remediation list per CIS IIS 8 Benchmark v1.4.0 - 08-24-2015 (minus 3DES)
+  # Removed DHE per ITSec on 4/6/16
+  # TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 and TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+  # --------------------------------------------------------------------
+  $cipherSuitesOrder = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384_P256, \
+                        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256_P256, \
+                        TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA_P256, \
+                        TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA_P256, \
+                        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384_P384, \
+                        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256_P256"
+
+  registry::value { 'Cipher Suites':
+    key   => 'HKLM\\SOFTWARE\\Policies\\Microsoft\\Cryptography\\Configuration\\SSL\\00010002',
+    type  => string,
+    value => 'Functions',
+    data  => $cipherSuitesOrder,
+  }
+
+   # --------------------------------------------------------------------
+  # Disable IP Source Routing - Microsoft Security Bulletin MS06-032
+  # --------------------------------------------------------------------
+  registry::value { 'DisableIPSourceRouting0':
+    key   => 'HKLM\\System\\CurrentControlSet\\Services\\Tcpip\\Parameters',
+    type  => 'dword',
+    value => 'DisableIPSourceRouting',
+    data  => 2,
+  }
+
+  # --------------------------------------------------------------------
+  # Disable IPv6 Source Routing - Microsoft Security Bulletin MS06-032
+  # --------------------------------------------------------------------
+  registry_value { 'HKLM\System\CurrentControlSet\Services\Tcpip6\Parameters\DisableIPSourceRouting':
+    ensure => present,
+  	type   => dword,
+    data   => 2,
+    notify => Reboot['after_run'],
+  }
+
+  #Reboot Computer
+  reboot { 'after_run':
+    apply => finished,
+  }
+
+}

--- a/server/spec/languageserver/integration/puppet-languageserver/document_validator_spec.rb
+++ b/server/spec/languageserver/integration/puppet-languageserver/document_validator_spec.rb
@@ -146,6 +146,18 @@ describe 'document_validator' do
       end
     end
 
+    describe "Given a complete manifest with linting errors" do
+      let(:manifest_fixture) { File.join($fixtures_dir,'manifest_with_lint_errors.pp') }
+      let(:manifest_lf) { File.open(manifest_fixture, 'r') { |file| file.read } }
+      let(:manifest_crlf) { File.open(manifest_fixture, 'r') { |file| file.read }.gsub("\n","\r\n") }
+
+      it "should return same errors for both LF and CRLF line endings" do
+        lint_error_lf = subject.validate(manifest_lf, nil)
+        lint_error_crlf = subject.validate(manifest_crlf, nil)
+        expect(lint_error_crlf).to eq(lint_error_lf)
+      end
+   end
+
     describe "Given a complete manifest with a single linting error" do
       let(:manifest) { "
         user { 'Bob':

--- a/server/spec/languageserver/spec_helper.rb
+++ b/server/spec/languageserver/spec_helper.rb
@@ -7,13 +7,13 @@ $LOAD_PATH.unshift(File.join(root,'lib'))
 $LOAD_PATH.unshift(File.join(root,'vendor','puppet-lint','lib'))
 
 require 'puppet-languageserver'
-fixtures_dir = File.join(File.dirname(__FILE__),'fixtures')
+$fixtures_dir = File.join(File.dirname(__FILE__),'fixtures')
 
 # Currently there is no way to re-initialize the puppet loader so for the moment
 # all tests must run off the single puppet config settings instead of per example setting
 server_options = PuppetLanguageServer::CommandLineParser.parse([])
-server_options[:puppet_settings] = ['--vardir',File.join(fixtures_dir,'cache'),
-                                    '--confdir',File.join(fixtures_dir,'confdir')]
+server_options[:puppet_settings] = ['--vardir',File.join($fixtures_dir,'cache'),
+                                    '--confdir',File.join($fixtures_dir,'confdir')]
 PuppetLanguageServer::init_puppet(server_options)
 
 def wait_for_puppet_loading

--- a/server/vendor/README.md
+++ b/server/vendor/README.md
@@ -12,3 +12,4 @@ Gem List
 --------
 
 * puppet-lint (https://github.com/rodjek/puppet-lint.git ref 2.3.5)
+

--- a/server/vendor/README.md
+++ b/server/vendor/README.md
@@ -11,4 +11,4 @@ Note - To improve the packaging size, test files etc. were stripped from the Gem
 Gem List
 --------
 
-* puppet-lint (https://github.com/rodjek/puppet-lint.git ref 2.3.3)
+* puppet-lint (https://github.com/rodjek/puppet-lint.git ref 2.3.5)

--- a/server/vendor/puppet-lint/.rubocop_todo.yml
+++ b/server/vendor/puppet-lint/.rubocop_todo.yml
@@ -60,7 +60,7 @@ Metrics/LineLength:
 # Offense count: 65
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 94
+  Max: 105
 
 # Offense count: 18
 Metrics/PerceivedComplexity:

--- a/server/vendor/puppet-lint/CHANGELOG.md
+++ b/server/vendor/puppet-lint/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Change Log
 
+## [2.3.5](https://github.com/rodjek/puppet-lint/tree/2.3.5) (2018-03-27)
+[Full Changelog](https://github.com/rodjek/puppet-lint/compare/2.3.4...2.3.5)
+
+**Fixed bugs:**
+
+- v2.3.4 breakage - 'wrong number of arguments' when using Rake task [\#812](https://github.com/rodjek/puppet-lint/issues/812)
+
+**Merged pull requests:**
+
+- Make PuppetLint::OptParser.build argument optional [\#813](https://github.com/rodjek/puppet-lint/pull/813) ([rodjek](https://github.com/rodjek))
+
+## [2.3.4](https://github.com/rodjek/puppet-lint/tree/2.3.4) (2018-03-26)
+[Full Changelog](https://github.com/rodjek/puppet-lint/compare/2.3.3...2.3.4)
+
+**Implemented enhancements:**
+
+- Allow ignoring default configurations files on the command line [\#787](https://github.com/rodjek/puppet-lint/issues/787)
+- Implement --list-checks feature, to list the names of all available checks from the cli. [\#804](https://github.com/rodjek/puppet-lint/pull/804) ([xraystyle](https://github.com/xraystyle))
+- Option to disable loading default configurations files [\#789](https://github.com/rodjek/puppet-lint/pull/789) ([dioni21](https://github.com/dioni21))
+- Allow passing ignore\_paths from cli [\#783](https://github.com/rodjek/puppet-lint/pull/783) ([keymone](https://github.com/keymone))
+
+**Fixed bugs:**
+
+- Bad value for range [\#801](https://github.com/rodjek/puppet-lint/issues/801)
+- puppet-lint doesn't handle CRLFs very well [\#778](https://github.com/rodjek/puppet-lint/issues/778)
+- Configuration's ignore\_paths is not respected [\#774](https://github.com/rodjek/puppet-lint/issues/774)
+- Error when including class and missing a colon [\#507](https://github.com/rodjek/puppet-lint/issues/507)
+
+**Merged pull requests:**
+
+- Handle single colon in resource name syntax error [\#809](https://github.com/rodjek/puppet-lint/pull/809) ([rodjek](https://github.com/rodjek))
+- \(\#778\) Don't include line ending in single line comment token values [\#782](https://github.com/rodjek/puppet-lint/pull/782) ([rodjek](https://github.com/rodjek))
+- Fix setting ignore\_paths in Rake task [\#777](https://github.com/rodjek/puppet-lint/pull/777) ([alzabo](https://github.com/alzabo))
+- Add support for passing backslash separated paths to puppet-lint [\#769](https://github.com/rodjek/puppet-lint/pull/769) ([rodjek](https://github.com/rodjek))
+
 ## [2.3.3](https://github.com/rodjek/puppet-lint/tree/2.3.3) (2017-09-28)
 [Full Changelog](https://github.com/rodjek/puppet-lint/compare/2.3.2...2.3.3)
 

--- a/server/vendor/puppet-lint/README.md
+++ b/server/vendor/puppet-lint/README.md
@@ -5,7 +5,7 @@ Status](https://secure.travis-ci.org/rodjek/puppet-lint.png)](http://travis-ci.o
 [![Inline docs](http://inch-ci.org/github/rodjek/puppet-lint.png?branch=master)](http://inch-ci.org/github/rodjek/puppet-lint)
 
 Puppet Lint tests Puppet code against the recommended [Puppet language style
-guide](http://docs.puppet.com/puppet/latest/style_guide.html). Puppet Lint validates only code style; it does not validate syntax. To test syntax, use Puppet's `puppet parser validate` command.
+guide](http://puppet.com/docs/puppet/latest/style_guide.html). Puppet Lint validates only code style; it does not validate syntax. To test syntax, use Puppet's `puppet parser validate` command.
 
 ## Compatibility warning
 
@@ -45,6 +45,10 @@ puppet-lint --fix /modules
 
 Puppet Lint options allow you to modify which checks to run. You can disable any of the checks temporarily or permanently, or you can limit testing to specific checks.
 
+#### List all available checks
+
+To list all available checks along with basic usage documentation, use the `--list-checks` option.
+
 #### Run specific checks
 
 To run only specific checks, use the `--only-checks` option, with a comma-separated list of arguments specifying which checks to make:
@@ -65,7 +69,7 @@ You can disable specific Lint checks on the command line, disable them permanent
 
 #### Disable checks on the command line
 
-To disable any of the checks when running the `puppet-lint` command, add a `--no-<check name>-check` flag to the command. For example, to skip the 140-character check, run:
+To disable any of the checks when running the `puppet-lint` command, add a `--no-<check_name>-check` flag to the command. For example, to skip the 140-character check, run:
 
 ```
 puppet-lint --no-140chars-check modules/

--- a/server/vendor/puppet-lint/Rakefile
+++ b/server/vendor/puppet-lint/Rakefile
@@ -12,7 +12,8 @@ begin
   GitHubChangelogGenerator::RakeTask.new(:changelog) do |config|
     version = PuppetLint::VERSION
     config.future_release = version.to_s
-    config.exclude_labels = %w[duplicate question invalid wontfix release-pr]
+    config.exclude_labels = %w[duplicate question invalid wontfix release-pr documentation]
+    config.enhancement_labels = %w[feature]
   end
 rescue LoadError
   $stderr.puts 'Changelog generation requires Ruby 2.0 or higher'
@@ -23,6 +24,14 @@ begin
 
   RuboCop::RakeTask.new(:rubocop) do |task|
     task.options = %w[-D -E]
+    task.patterns = [
+      'lib/**/*.rb',
+      'spec/**/*.rb',
+      'bin/*',
+      '*.gemspec',
+      'Gemfile',
+      'Rakefile',
+    ]
   end
 rescue LoadError
   $stderr.puts 'Rubocop is not available for this version of Ruby.'

--- a/server/vendor/puppet-lint/lib/puppet-lint.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint.rb
@@ -13,6 +13,15 @@ require 'puppet-lint/monkeypatches'
 class PuppetLint::NoCodeError < StandardError; end
 class PuppetLint::NoFix < StandardError; end
 
+# Parser Syntax Errors
+class PuppetLint::SyntaxError < StandardError
+  attr_reader :token
+
+  def initialize(token)
+    @token = token
+  end
+end
+
 # Public: The public interface to puppet-lint.
 class PuppetLint
   # Public: Gets/Sets the String manifest code to be checked.
@@ -75,7 +84,7 @@ class PuppetLint
     return unless File.exist?(path)
 
     @path = path
-    File.open(path, 'r:UTF-8') do |f|
+    File.open(path, 'rb:UTF-8') do |f|
       @code = f.read
     end
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/checks.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/checks.rb
@@ -67,6 +67,19 @@ class PuppetLint::Checks
     end
 
     @problems
+  rescue PuppetLint::SyntaxError => e
+    @problems << {
+      :kind     => :error,
+      :check    => :syntax,
+      :message  => 'Syntax error',
+      :fullpath => File.expand_path(fileinfo, ENV['PWD']),
+      :filename => File.basename(fileinfo),
+      :path     => fileinfo,
+      :line     => e.token.line,
+      :column   => e.token.column,
+    }
+
+    @problems
   rescue => e
     $stdout.puts <<-END.gsub(%r{^ {6}}, '')
       Whoops! It looks like puppet-lint has encountered an error that it doesn't

--- a/server/vendor/puppet-lint/lib/puppet-lint/data.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/data.rb
@@ -176,6 +176,8 @@ class PuppetLint::Data
           end_token = colon_token.next_token_of([:SEMIC, :RBRACE])
           end_idx = tokens.index(end_token)
 
+          raise PuppetLint::SyntaxError, colon_token if end_idx.nil?
+
           result << {
             :start        => start_idx + 1,
             :end          => end_idx,

--- a/server/vendor/puppet-lint/lib/puppet-lint/optparser.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/optparser.rb
@@ -17,12 +17,17 @@ class PuppetLint::OptParser
   # Public: Initialise a new puppet-lint OptionParser.
   #
   # Returns an OptionParser object.
-  def self.build
-    OptionParser.new do |opts|
+  def self.build(args = [])
+    noconfig = false
+    opt_parser = OptionParser.new do |opts|
       opts.banner = HELP_TEXT
 
       opts.on('--version', 'Display the current version.') do
         PuppetLint.configuration.display_version = true
+      end
+
+      opts.on('--no-config', 'Do not load default puppet-lint option files.') do
+        noconfig = true
       end
 
       opts.on('-c', '--config FILE', 'Load puppet-lint options from file.') do |file|
@@ -94,6 +99,10 @@ class PuppetLint::OptParser
         PuppetLint.configuration.json = true
       end
 
+      opts.on('--list-checks', 'List available check names.') do
+        PuppetLint.configuration.list_checks = true
+      end
+
       opts.separator('')
       opts.separator('    Checks:')
 
@@ -108,6 +117,10 @@ class PuppetLint::OptParser
         end
       end
 
+      opts.on('--ignore-paths PATHS', 'A comma separated list of patterns to ignore') do |paths|
+        PuppetLint.configuration.ignore_paths = paths.split(',')
+      end
+
       PuppetLint.configuration.checks.each do |check|
         opts.on("--no-#{check}-check", "Skip the #{check} check.") do
           PuppetLint.configuration.send("disable_#{check}")
@@ -119,13 +132,19 @@ class PuppetLint::OptParser
           PuppetLint.configuration.send("enable_#{check}")
         end
       end
+    end
 
-      opts.load('/etc/puppet-lint.rc')
+    opt_parser.parse!(args) unless args.empty?
+
+    unless noconfig
+      opt_parser.load('/etc/puppet-lint.rc')
       if ENV.key?('HOME') && File.readable?(ENV['HOME'])
         home_dotfile_path = File.expand_path('~/.puppet-lint.rc')
-        opts.load(home_dotfile_path) if File.readable?(home_dotfile_path)
+        opt_parser.load(home_dotfile_path) if File.readable?(home_dotfile_path)
       end
-      opts.load('.puppet-lint.rc')
+      opt_parser.load('.puppet-lint.rc')
     end
+
+    opt_parser
   end
 end

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/arrow_on_right_operand_line.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for chaining arrow that is
 # on the line of the left operand when the right operand is on another line.
 #
-# https://docs.puppet.com/guides/style_guide.html#chaining-arrow-syntax
+# https://puppet.com/docs/puppet/latest/style_guide.html#chaining-arrow-syntax
 PuppetLint.new_check(:arrow_on_right_operand_line) do
   def check
     tokens.select { |r| Set[:IN_EDGE, :IN_EDGE_SUB].include?(r.type) }.each do |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/autoloader_layout.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/autoloader_layout.rb
@@ -2,7 +2,7 @@
 # not in an appropriately named file for the autoloader to detect and record
 # an error of each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#separate-files
+# https://puppet.com/docs/puppet/latest/style_guide.html#separate-files
 PuppetLint.new_check(:autoloader_layout) do
   def check
     return if fullpath.nil? || fullpath == ''

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/inherits_across_namespaces.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/inherits_across_namespaces.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for any classes that inherit across
 # namespaces and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#class-inheritance
+# https://puppet.com/docs/puppet/latest/style_guide.html#class-inheritance
 PuppetLint.new_check(:inherits_across_namespaces) do
   def check
     class_indexes.each do |class_idx|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/names_containing_uppercase.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/names_containing_uppercase.rb
@@ -1,6 +1,6 @@
 # Public: Find and warn about module names with illegal uppercase characters.
 #
-# https://docs.puppet.com/puppet/latest/reference/modules_fundamentals.html#allowed-module-names
+# https://puppet.com/docs/puppet/latest/modules_fundamentals.html#allowed-module-names
 # Provides a fix. [puppet-lint #554]
 PuppetLint.new_check(:names_containing_uppercase) do
   def check

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/nested_classes_or_defines.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/nested_classes_or_defines.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for any classes or defined types that are
 # defined inside another class.
 #
-# https://docs.puppet.com/guides/style_guide.html#nested-classes-or-defined-types
+# https://puppet.com/docs/puppet/latest/style_guide.html#nested-classes-or-defined-types
 PuppetLint.new_check(:nested_classes_or_defines) do
   TOKENS = Set[:CLASS, :DEFINE]
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/parameter_order.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/parameter_order.rb
@@ -2,7 +2,7 @@
 # types that take parameters and record a warning if there are any optional
 # parameters listed before required parameters.
 #
-# https://docs.puppet.com/guides/style_guide.html#display-order-of-parameters
+# https://puppet.com/docs/puppet/latest/style_guide.html#display-order-of-parameters
 PuppetLint.new_check(:parameter_order) do
   def check
     (class_indexes + defined_type_indexes).each do |class_idx|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/right_to_left_relationship.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/right_to_left_relationship.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for any right-to-left (<-) chaining
 # operators and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#chaining-arrow-syntax
+# https://puppet.com/docs/puppet/latest/style_guide.html#chaining-arrow-syntax
 PuppetLint.new_check(:right_to_left_relationship) do
   def check
     tokens.select { |r| r.type == :OUT_EDGE }.each do |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/variable_scope.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_classes/variable_scope.rb
@@ -4,7 +4,7 @@
 # defined in the local scope and record a warning for each variable that has
 # not.
 #
-# https://docs.puppet.com/guides/style_guide.html#namespacing-variables
+# https://puppet.com/docs/puppet/latest/style_guide.html#namespacing-variables
 PuppetLint.new_check(:variable_scope) do
   DEFAULT_SCOPE_VARS = Set[
     'name',

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_comments/slash_comments.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_comments/slash_comments.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any comments started with slashes
 # (//) and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#comments
+# https://puppet.com/docs/puppet/latest/style_guide.html#comments
 PuppetLint.new_check(:slash_comments) do
   def check
     tokens.select { |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_comments/star_comments.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_comments/star_comments.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any comments encapsulated with
 # slash-asterisks (/* */) and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#comments
+# https://puppet.com/docs/puppet/latest/style_guide.html#comments
 PuppetLint.new_check(:star_comments) do
   def check
     tokens.select { |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_conditionals/case_without_default.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_conditionals/case_without_default.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for any case statements that do not
 # contain a "default" case and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#defaults-for-case-statements-and-selectors
+# https://puppet.com/docs/puppet/latest/style_guide.html#defaults-for-case-statements-and-selectors
 PuppetLint.new_check(:case_without_default) do
   def check
     case_indexes = []

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_conditionals/selector_inside_resource.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_conditionals/selector_inside_resource.rb
@@ -1,7 +1,7 @@
 # Public: Test the manifest tokens for any selectors embedded within resource
 # declarations and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#keep-resource-declarations-simple
+# https://puppet.com/docs/puppet/latest/style_guide.html#keep-resource-declarations-simple
 PuppetLint.new_check(:selector_inside_resource) do
   def check
     resource_indexes.each do |resource|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_documentation/documentation.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_documentation/documentation.rb
@@ -2,7 +2,7 @@
 # have a comment directly above it (hopefully, explaining the usage of it) and
 # record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#public-and-private
+# https://puppet.com/docs/puppet/latest/style_guide.html#public-and-private
 PuppetLint.new_check(:documentation) do
   COMMENT_TOKENS = Set[:COMMENT, :MLCOMMENT, :SLASH_COMMENT]
   WHITESPACE_TOKENS = Set[:WHITESPACE, :NEWLINE, :INDENT]

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/ensure_first_param.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/ensure_first_param.rb
@@ -2,7 +2,7 @@
 # and if found, check that it is the first parameter listed.  If it is not
 # the first parameter, record a warning.
 #
-# https://docs.puppet.com/guides/style_guide.html#attribute-ordering
+# https://puppet.com/docs/puppet/latest/style_guide.html#attribute-ordering
 PuppetLint.new_check(:ensure_first_param) do
   def check
     resource_indexes.each do |resource|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/ensure_not_symlink_target.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/ensure_not_symlink_target.rb
@@ -2,7 +2,7 @@
 # parameter and record a warning if the value of that parameter looks like
 # a symlink target (starts with a '/').
 #
-# https://docs.puppet.com/guides/style_guide.html#symbolic-links
+# https://puppet.com/docs/puppet/latest/style_guide.html#symbolic-links
 PuppetLint.new_check(:ensure_not_symlink_target) do
   def check
     resource_indexes.each do |resource|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/file_mode.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/file_mode.rb
@@ -2,7 +2,7 @@
 # parameter and if found, record a warning if the value of that parameter is
 # not a 4 digit octal value (0755) or a symbolic mode ('o=rwx,g+r').
 #
-# https://docs.puppet.com/guides/style_guide.html#file-modes
+# https://puppet.com/docs/puppet/latest/style_guide.html#file-modes
 PuppetLint.new_check(:file_mode) do
   MSG = 'mode should be represented as a 4 digit octal value or symbolic mode'.freeze
   SYM_RE = '([ugoa]*[-=+][-=+rstwxXugo]*)(,[ugoa]*[-=+][-=+rstwxXugo]*)*'.freeze

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/unquoted_file_mode.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/unquoted_file_mode.rb
@@ -2,7 +2,7 @@
 # parameter and if found, record a warning if the value of that parameter is
 # not a quoted string.
 #
-# https://docs.puppet.com/guides/style_guide.html#file-modes
+# https://puppet.com/docs/puppet/latest/style_guide.html#file-modes
 PuppetLint.new_check(:unquoted_file_mode) do
   TOKEN_TYPES = Set[:NAME, :NUMBER]
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/unquoted_resource_title.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_resources/unquoted_resource_title.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any resource titles / namevars that
 # are not quoted and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#resource-names
+# https://puppet.com/docs/puppet/latest/style_guide.html#resource-names
 PuppetLint.new_check(:unquoted_resource_title) do
   def check
     title_tokens.each do |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/double_quoted_strings.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/double_quoted_strings.rb
@@ -2,7 +2,7 @@
 # contain any variables or common escape characters and record a warning for
 # each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#quoting
+# https://puppet.com/docs/puppet/latest/style_guide.html#quoting
 PuppetLint.new_check(:double_quoted_strings) do
   ESCAPE_CHAR_RE = %r{(\\\$|\\"|\\'|'|\r|\t|\\t|\n|\\n|\\\\)}
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/only_variable_string.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/only_variable_string.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for double quoted strings that contain
 # a single variable only and record a warning for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#quoting
+# https://puppet.com/docs/puppet/latest/style_guide.html#quoting
 PuppetLint.new_check(:only_variable_string) do
   VAR_TYPES = Set[:VARIABLE, :UNENC_VARIABLE]
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/single_quote_string_with_variables.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/single_quote_string_with_variables.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any single quoted strings containing
 # a enclosed variable and record an error for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#quoting
+# https://puppet.com/docs/puppet/latest/style_guide.html#quoting
 PuppetLint.new_check(:single_quote_string_with_variables) do
   def check
     tokens.select { |r|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/variables_not_enclosed.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_strings/variables_not_enclosed.rb
@@ -2,7 +2,7 @@
 # not been enclosed by braces ({}) and record a warning for each instance
 # found.
 #
-# https://docs.puppet.com/guides/style_guide.html#quoting
+# https://puppet.com/docs/puppet/latest/style_guide.html#quoting
 PuppetLint.new_check(:variables_not_enclosed) do
   def check
     tokens.select { |r|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/140chars.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/140chars.rb
@@ -3,7 +3,7 @@
 # to this rule are lines containing URLs and template() calls which would hurt
 # readability if split.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
 PuppetLint.new_check(:'140chars') do
   def check
     manifest_lines.each_with_index do |line, idx|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/2sp_soft_tabs.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/2sp_soft_tabs.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any indentation not using 2 space soft
 # tabs and record an error for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
 PuppetLint.new_check(:'2sp_soft_tabs') do
   def check
     tokens.select { |r|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/80chars.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/80chars.rb
@@ -2,7 +2,7 @@
 # characters. This is DISABLED by default and behaves like the default
 # 140chars check by excepting URLs and template() calls.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace (older version)
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace (older version)
 PuppetLint.new_check(:'80chars') do
   def check
     manifest_lines.each_with_index do |line, idx|

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/arrow_alignment.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/arrow_alignment.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for any arrows (=>) in a grouping ({}) that
 # are not aligned with other arrows in that grouping.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
 PuppetLint.new_check(:arrow_alignment) do
   COMMENT_TYPES = Set[:COMMENT, :SLASH_COMMENT, :MLCOMMENT]
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/hard_tabs.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/hard_tabs.rb
@@ -1,7 +1,7 @@
 # Public: Check the raw manifest string for lines containing hard tab
 # characters and record an error for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
 PuppetLint.new_check(:hard_tabs) do
   WHITESPACE_TYPES = Set[:INDENT, :WHITESPACE]
 

--- a/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/plugins/check_whitespace/trailing_whitespace.rb
@@ -1,7 +1,7 @@
 # Public: Check the manifest tokens for lines ending with whitespace and record
 # an error for each instance found.
 #
-# https://docs.puppet.com/guides/style_guide.html#spacing-indentation-and-whitespace
+# https://puppet.com/docs/puppet/latest/style_guide.html#spacing-indentation-and-whitespace
 PuppetLint.new_check(:trailing_whitespace) do
   def check
     tokens.select { |token|

--- a/server/vendor/puppet-lint/lib/puppet-lint/tasks/gemfile_rewrite.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/tasks/gemfile_rewrite.rb
@@ -1,0 +1,20 @@
+require 'parser/current'
+
+# Simple rewriter using whitequark/parser that rewrites the "gem 'puppet-lint'"
+# entry in the module's Gemfile (if present) to instead use the local
+# puppet-lint working directory.
+class GemfileRewrite < Parser::TreeRewriter
+  def on_send(node)
+    _, method_name, *args = *node
+
+    if method_name == :gem
+      gem_name = args.first
+      if gem_name.type == :str && gem_name.children.first == 'puppet-lint'
+        puppet_lint_root = File.expand_path(File.join(__FILE__, '..', '..', '..', '..'))
+        replace(node.location.expression, "gem 'puppet-lint', :path => '#{puppet_lint_root}'")
+      end
+    end
+
+    super
+  end
+end

--- a/server/vendor/puppet-lint/lib/puppet-lint/tasks/puppet-lint.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/tasks/puppet-lint.rb
@@ -64,8 +64,8 @@ class PuppetLint
           PuppetLint.configuration.send("#{config}=".to_sym, value) unless value.nil?
         end
 
-        if PuppetLint.configuration.ignore_paths
-          @ignore_paths ||= PuppetLint.configuration.ignore_paths
+        if PuppetLint.configuration.ignore_paths && @ignore_paths.empty?
+          @ignore_paths = PuppetLint.configuration.ignore_paths
         end
 
         if PuppetLint.configuration.pattern

--- a/server/vendor/puppet-lint/lib/puppet-lint/version.rb
+++ b/server/vendor/puppet-lint/lib/puppet-lint/version.rb
@@ -1,3 +1,3 @@
 class PuppetLint
-  VERSION = '2.3.3'.freeze
+  VERSION = '2.3.5'.freeze
 end


### PR DESCRIPTION
This commit updates puppet-lint to 2.3.5 which has some fixes for CRLF handling.

---

This commit adds a test and test fixture to ensure that the document validator
returns the same linting errors regardless of CRLF or LF line endings.